### PR TITLE
Fix JavaDoc issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,20 +104,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
                 <configuration>
@@ -128,32 +114,6 @@
                         </manifest>
                     </archive>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -235,17 +195,67 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/io/skelp/verifier/CustomVerifier.java
+++ b/src/main/java/io/skelp/verifier/CustomVerifier.java
@@ -45,12 +45,12 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(null).equalTo(null)   => PASS
-     * Verifier.verify(null).equalTo("abc")  => FAIL
-     * Verifier.verify("abc").equalTo(null)  => FAIL
-     * Verifier.verify("abc").equalTo("abc") => PASS
-     * Verifier.verify("abc").equalTo("ABC") => FAIL
-     * Verifier.verify("abc").equalTo("def") => FAIL
+     * Verifier.verify(null).equalTo(null)   =&gt; PASS
+     * Verifier.verify(null).equalTo("abc")  =&gt; FAIL
+     * Verifier.verify("abc").equalTo(null)  =&gt; FAIL
+     * Verifier.verify("abc").equalTo("abc") =&gt; PASS
+     * Verifier.verify("abc").equalTo("ABC") =&gt; FAIL
+     * Verifier.verify("abc").equalTo("def") =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -76,12 +76,12 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(null, *).equalTo(null)   => PASS
-     * Verifier.verify(null, *).equalTo("abc")  => FAIL
-     * Verifier.verify("abc", *).equalTo(null)  => FAIL
-     * Verifier.verify("abc", *).equalTo("abc") => PASS
-     * Verifier.verify("abc", *).equalTo("ABC") => FAIL
-     * Verifier.verify("abc", *).equalTo("def") => FAIL
+     * Verifier.verify(null, *).equalTo(null)   =&gt; PASS
+     * Verifier.verify(null, *).equalTo("abc")  =&gt; FAIL
+     * Verifier.verify("abc", *).equalTo(null)  =&gt; FAIL
+     * Verifier.verify("abc", *).equalTo("abc") =&gt; PASS
+     * Verifier.verify("abc", *).equalTo("ABC") =&gt; FAIL
+     * Verifier.verify("abc", *).equalTo("def") =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -104,13 +104,13 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).equalToAny()                         => FAIL
-     * Verifier.verify(*).equalToAny((Object[]) null)          => FAIL
-     * Verifier.verify(null).equalToAny("ghi", "def", null)    => PASS
-     * Verifier.verify(null).equalToAny("ghi", "def", "abc")   => FAIL
-     * Verifier.verify("abc").equalToAny("ghi", "def", null)   => FAIL
-     * Verifier.verify("abc").equalToAny("ghi", "def", "abc")  => PASS
-     * Verifier.verify("abc").equalToAny("GHI", "DEF", "ABC")  => FAIL
+     * Verifier.verify(*).equalToAny()                         =&gt; FAIL
+     * Verifier.verify(*).equalToAny((Object[]) null)          =&gt; FAIL
+     * Verifier.verify(null).equalToAny("ghi", "def", null)    =&gt; PASS
+     * Verifier.verify(null).equalToAny("ghi", "def", "abc")   =&gt; FAIL
+     * Verifier.verify("abc").equalToAny("ghi", "def", null)   =&gt; FAIL
+     * Verifier.verify("abc").equalToAny("ghi", "def", "abc")  =&gt; PASS
+     * Verifier.verify("abc").equalToAny("GHI", "DEF", "ABC")  =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -130,11 +130,11 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(null).hashedAs(*)   => FAIL
-     * Verifier.verify(123).hashedAs(0)    => FAIL
-     * Verifier.verify(123).hashedAs(321)  => FAIL
-     * Verifier.verify(123).hashedAs(123)  => PASS
-     * Verifier.verify(123).hashedAs(-123) => FAIL
+     * Verifier.verify(null).hashedAs(*)   =&gt; FAIL
+     * Verifier.verify(123).hashedAs(0)    =&gt; FAIL
+     * Verifier.verify(123).hashedAs(321)  =&gt; FAIL
+     * Verifier.verify(123).hashedAs(123)  =&gt; PASS
+     * Verifier.verify(123).hashedAs(-123) =&gt; FAIL
      * </pre>
      *
      * @param hashCode
@@ -154,11 +154,11 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).instanceOf(null)                           => FAIL
-     * Verifier.verify(*).instanceOf(Object.class)                   => PASS
-     * Verifier.verify(null).instanceOf(*)                           => FAIL
-     * Verifier.verify(new ArrayList()).instanceOf(Collection.class) => PASS
-     * Verifier.verify(new ArrayList()).instanceOf(Map.class)        => FAIL
+     * Verifier.verify(*).instanceOf(null)                           =&gt; FAIL
+     * Verifier.verify(*).instanceOf(Object.class)                   =&gt; PASS
+     * Verifier.verify(null).instanceOf(*)                           =&gt; FAIL
+     * Verifier.verify(new ArrayList()).instanceOf(Collection.class) =&gt; PASS
+     * Verifier.verify(new ArrayList()).instanceOf(Map.class)        =&gt; FAIL
      * </pre>
      *
      * @param cls
@@ -178,13 +178,13 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).instanceOfAll()                                                            => PASS
-     * Verifier.verify(*).instanceOfAll((Object[]) null)                                             => PASS
-     * Verifier.verify(*).instanceOfAll(Object.class)                                                => PASS
-     * Verifier.verify(*).instanceOfAll(*, null)                                                     => FAIL
-     * Verifier.verify(null).instanceOfAll(*)                                                        => FAIL
-     * Verifier.verify(new ArrayList()).instanceOfAll(ArrayList.class, List.class, Collection.class) => PASS
-     * Verifier.verify(new ArrayList()).instanceOfAll(ArrayList.class, Map.class, Collection.class)  => FAIL
+     * Verifier.verify(*).instanceOfAll()                                                            =&gt; PASS
+     * Verifier.verify(*).instanceOfAll((Object[]) null)                                             =&gt; PASS
+     * Verifier.verify(*).instanceOfAll(Object.class)                                                =&gt; PASS
+     * Verifier.verify(*).instanceOfAll(*, null)                                                     =&gt; FAIL
+     * Verifier.verify(null).instanceOfAll(*)                                                        =&gt; FAIL
+     * Verifier.verify(new ArrayList()).instanceOfAll(ArrayList.class, List.class, Collection.class) =&gt; PASS
+     * Verifier.verify(new ArrayList()).instanceOfAll(ArrayList.class, Map.class, Collection.class)  =&gt; FAIL
      * </pre>
      *
      * @param classes
@@ -205,12 +205,12 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).instanceOfAny()                                                         => FAIL
-     * Verifier.verify(*).instanceOfAny((Object[]) null)                                          => FAIL
-     * Verifier.verify(*).instanceOfAny(*, Object.class)                                          => PASS
-     * Verifier.verify(null).instanceOfAny(*)                                                     => FAIL
-     * Verifier.verify(new ArrayList()).instanceOfAny(Boolean.class, Map.class, Collection.class) => PASS
-     * Verifier.verify(new ArrayList()).instanceOfAny(Boolean.class, Map.class, URI.class)        => FAIL
+     * Verifier.verify(*).instanceOfAny()                                                         =&gt; FAIL
+     * Verifier.verify(*).instanceOfAny((Object[]) null)                                          =&gt; FAIL
+     * Verifier.verify(*).instanceOfAny(*, Object.class)                                          =&gt; PASS
+     * Verifier.verify(null).instanceOfAny(*)                                                     =&gt; FAIL
+     * Verifier.verify(new ArrayList()).instanceOfAny(Boolean.class, Map.class, Collection.class) =&gt; PASS
+     * Verifier.verify(new ArrayList()).instanceOfAny(Boolean.class, Map.class, URI.class)        =&gt; FAIL
      * </pre>
      *
      * @param classes
@@ -232,10 +232,10 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * itself.
      * </p>
      * <pre>
-     * Verifier.verify(null).not().nulled()               => FAIL
-     * Verifier.verify(new Object()).not().nulled()       => PASS
-     * Verifier.verify(null).not().not().nulled()         => PASS
-     * Verifier.verify(new Object()).not().not().nulled() => FAIL
+     * Verifier.verify(null).not().nulled()               =&gt; FAIL
+     * Verifier.verify(new Object()).not().nulled()       =&gt; PASS
+     * Verifier.verify(null).not().not().nulled()         =&gt; PASS
+     * Verifier.verify(new Object()).not().not().nulled() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CustomVerifier} for chaining purposes.
@@ -247,8 +247,8 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * Verifies that the value {@literal null}.
      * </p>
      * <pre>
-     * Verifier.verify(null).nulled()         => PASS
-     * Verifier.verify(new Object()).nulled() => FAIL
+     * Verifier.verify(null).nulled()         =&gt; PASS
+     * Verifier.verify(new Object()).nulled() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CustomVerifier} for chaining purposes.
@@ -265,11 +265,11 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(null).sameAs(null)            => PASS
-     * Verifier.verify(null).sameAs(123)             => FAIL
-     * Verifier.verify(123).sameAs(null)             => FAIL
-     * Verifier.verify(123).sameAs(123)              => PASS
-     * Verifier.verify(213).sameAs(new Integer(123)) => FAIL
+     * Verifier.verify(null).sameAs(null)            =&gt; PASS
+     * Verifier.verify(null).sameAs(123)             =&gt; FAIL
+     * Verifier.verify(123).sameAs(null)             =&gt; FAIL
+     * Verifier.verify(123).sameAs(123)              =&gt; PASS
+     * Verifier.verify(213).sameAs(new Integer(123)) =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -294,11 +294,11 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(null, *).sameAs(null)            => PASS
-     * Verifier.verify(null, *).sameAs(123)             => FAIL
-     * Verifier.verify(123, *).sameAs(null)             => FAIL
-     * Verifier.verify(123, *).sameAs(123)              => PASS
-     * Verifier.verify(213, *).sameAs(new Integer(123)) => FAIL
+     * Verifier.verify(null, *).sameAs(null)            =&gt; PASS
+     * Verifier.verify(null, *).sameAs(123)             =&gt; FAIL
+     * Verifier.verify(123, *).sameAs(null)             =&gt; FAIL
+     * Verifier.verify(123, *).sameAs(123)              =&gt; PASS
+     * Verifier.verify(213, *).sameAs(new Integer(123)) =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -320,13 +320,13 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameAsAny()                                                       => FAIL
-     * Verifier.verify(*).sameAsAny((Object[]) null)                                        => FAIL
-     * Verifier.verify(null).sameAsAny(789, 456, null)                                      => PASS
-     * Verifier.verify(null).sameAsAny(789, 456, 123)                                       => FAIL
-     * Verifier.verify(123).sameAsAny(789, 456, null)                                       => FAIL
-     * Verifier.verify(123).sameAsAny(789, 456, 123)                                        => PASS
-     * Verifier.verify(123).sameAsAny(new Integer(789), new Integer(456), new Integer(123)) => FAIL
+     * Verifier.verify(*).sameAsAny()                                                       =&gt; FAIL
+     * Verifier.verify(*).sameAsAny((Object[]) null)                                        =&gt; FAIL
+     * Verifier.verify(null).sameAsAny(789, 456, null)                                      =&gt; PASS
+     * Verifier.verify(null).sameAsAny(789, 456, 123)                                       =&gt; FAIL
+     * Verifier.verify(123).sameAsAny(789, 456, null)                                       =&gt; FAIL
+     * Verifier.verify(123).sameAsAny(789, 456, 123)                                        =&gt; PASS
+     * Verifier.verify(123).sameAsAny(new Integer(789), new Integer(456), new Integer(123)) =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -342,11 +342,11 @@ public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
      * Verifies that the value passes the {@code assertion} provided.
      * </p>
      * <pre>
-     * Verifier.verify(*).that(null)                                                  => FAIL
-     * Verifier.verify(*).not().that(null)                                            => FAIL
-     * Verifier.verify(null).that(value -> "Mork".equals(value))                      => FAIL
-     * Verifier.verify(new User("Mork")).that(user -> "Mork".equals(user.getName()))  => PASS
-     * Verifier.verify(new User("Mindy")).that(user -> "Mork".equals(user.getName())) => FAIL
+     * Verifier.verify(*).that(null)                                                     =&gt; FAIL
+     * Verifier.verify(*).not().that(null)                                               =&gt; FAIL
+     * Verifier.verify(null).that(value -&gt; "Mork".equals(value))                      =&gt; FAIL
+     * Verifier.verify(new User("Mork")).that(user -&gt; "Mork".equals(user.getName()))  =&gt; PASS
+     * Verifier.verify(new User("Mindy")).that(user -&gt; "Mork".equals(user.getName())) =&gt; FAIL
      * </pre>
      *
      * @param assertion

--- a/src/main/java/io/skelp/verifier/type/CharacterVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/CharacterVerifier.java
@@ -73,12 +73,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is a letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).alpha() => FAIL
-     * Verifier.verify('\0').alpha()             => FAIL
-     * Verifier.verify('0').alpha()              => FAIL
-     * Verifier.verify('Z').alpha()              => PASS
-     * Verifier.verify('१').alpha()              => FAIL
-     * Verifier.verify('É').alpha()              => PASS
+     * Verifier.verify((Character) null).alpha() =&gt; FAIL
+     * Verifier.verify('\0').alpha()             =&gt; FAIL
+     * Verifier.verify('0').alpha()              =&gt; FAIL
+     * Verifier.verify('Z').alpha()              =&gt; PASS
+     * Verifier.verify('१').alpha()              =&gt; FAIL
+     * Verifier.verify('É').alpha()              =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -100,12 +100,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is a letter or digit.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).alphanumeric() => FAIL
-     * Verifier.verify('\0').alphanumeric()             => FAIL
-     * Verifier.verify('0').alphanumeric()              => PASS
-     * Verifier.verify('Z').alphanumeric()              => PASS
-     * Verifier.verify('१').alphanumeric()              => PASS
-     * Verifier.verify('É').alphanumeric()              => PASS
+     * Verifier.verify((Character) null).alphanumeric() =&gt; FAIL
+     * Verifier.verify('\0').alphanumeric()             =&gt; FAIL
+     * Verifier.verify('0').alphanumeric()              =&gt; PASS
+     * Verifier.verify('Z').alphanumeric()              =&gt; PASS
+     * Verifier.verify('१').alphanumeric()              =&gt; PASS
+     * Verifier.verify('É').alphanumeric()              =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -127,12 +127,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is ASCII.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).ascii() => FAIL
-     * Verifier.verify('\0').ascii()             => PASS
-     * Verifier.verify('0').ascii()              => PASS
-     * Verifier.verify('Z').ascii()              => PASS
-     * Verifier.verify('१').ascii()              => FAIL
-     * Verifier.verify('É').ascii()              => FAIL
+     * Verifier.verify((Character) null).ascii() =&gt; FAIL
+     * Verifier.verify('\0').ascii()             =&gt; PASS
+     * Verifier.verify('0').ascii()              =&gt; PASS
+     * Verifier.verify('Z').ascii()              =&gt; PASS
+     * Verifier.verify('१').ascii()              =&gt; FAIL
+     * Verifier.verify('É').ascii()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -153,12 +153,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiAlpha() => FAIL
-     * Verifier.verify('\0').asciiAlpha()             => FAIL
-     * Verifier.verify('0').asciiAlpha()              => FAIL
-     * Verifier.verify('Z').asciiAlpha()              => PASS
-     * Verifier.verify('१').asciiAlpha()              => FAIL
-     * Verifier.verify('É').asciiAlpha()              => FAIL
+     * Verifier.verify((Character) null).asciiAlpha() =&gt; FAIL
+     * Verifier.verify('\0').asciiAlpha()             =&gt; FAIL
+     * Verifier.verify('0').asciiAlpha()              =&gt; FAIL
+     * Verifier.verify('Z').asciiAlpha()              =&gt; PASS
+     * Verifier.verify('१').asciiAlpha()              =&gt; FAIL
+     * Verifier.verify('É').asciiAlpha()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -180,13 +180,13 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII lower case letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiAlphaLowerCase() => FAIL
-     * Verifier.verify('\0').asciiAlphaLowerCase()             => FAIL
-     * Verifier.verify('0').asciiAlphaLowerCase()              => FAIL
-     * Verifier.verify('a').asciiAlphaLowerCase()              => PASS
-     * Verifier.verify('Z').asciiAlphaLowerCase()              => FAIL
-     * Verifier.verify('१').asciiAlphaLowerCase()              => FAIL
-     * Verifier.verify('é').asciiAlphaLowerCase()              => FAIL
+     * Verifier.verify((Character) null).asciiAlphaLowerCase() =&gt; FAIL
+     * Verifier.verify('\0').asciiAlphaLowerCase()             =&gt; FAIL
+     * Verifier.verify('0').asciiAlphaLowerCase()              =&gt; FAIL
+     * Verifier.verify('a').asciiAlphaLowerCase()              =&gt; PASS
+     * Verifier.verify('Z').asciiAlphaLowerCase()              =&gt; FAIL
+     * Verifier.verify('१').asciiAlphaLowerCase()              =&gt; FAIL
+     * Verifier.verify('é').asciiAlphaLowerCase()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -209,13 +209,13 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII upper case letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiAlphaUpperCase() => FAIL
-     * Verifier.verify('\0').asciiAlphaUpperCase()             => FAIL
-     * Verifier.verify('0').asciiAlphaUpperCase()              => FAIL
-     * Verifier.verify('a').asciiAlphaUpperCase()              => FAIL
-     * Verifier.verify('Z').asciiAlphaUpperCase()              => PASS
-     * Verifier.verify('१').asciiAlphaUpperCase()              => FAIL
-     * Verifier.verify('É').asciiAlphaUpperCase()              => FAIL
+     * Verifier.verify((Character) null).asciiAlphaUpperCase() =&gt; FAIL
+     * Verifier.verify('\0').asciiAlphaUpperCase()             =&gt; FAIL
+     * Verifier.verify('0').asciiAlphaUpperCase()              =&gt; FAIL
+     * Verifier.verify('a').asciiAlphaUpperCase()              =&gt; FAIL
+     * Verifier.verify('Z').asciiAlphaUpperCase()              =&gt; PASS
+     * Verifier.verify('१').asciiAlphaUpperCase()              =&gt; FAIL
+     * Verifier.verify('É').asciiAlphaUpperCase()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -238,12 +238,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII letter or digit.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiAlphanumeric() => FAIL
-     * Verifier.verify('\0').asciiAlphanumeric()             => FAIL
-     * Verifier.verify('0').asciiAlphanumeric()              => PASS
-     * Verifier.verify('Z').asciiAlphanumeric()              => PASS
-     * Verifier.verify('१').asciiAlphanumeric()              => FAIL
-     * Verifier.verify('É').asciiAlphanumeric()              => FAIL
+     * Verifier.verify((Character) null).asciiAlphanumeric() =&gt; FAIL
+     * Verifier.verify('\0').asciiAlphanumeric()             =&gt; FAIL
+     * Verifier.verify('0').asciiAlphanumeric()              =&gt; PASS
+     * Verifier.verify('Z').asciiAlphanumeric()              =&gt; PASS
+     * Verifier.verify('१').asciiAlphanumeric()              =&gt; FAIL
+     * Verifier.verify('É').asciiAlphanumeric()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -265,12 +265,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII control.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiControl() => FAIL
-     * Verifier.verify('\0').asciiControl()             => PASS
-     * Verifier.verify('0').asciiControl()              => FAIL
-     * Verifier.verify('Z').asciiControl()              => FAIL
-     * Verifier.verify('१').asciiControl()              => FAIL
-     * Verifier.verify('É').asciiControl()              => FAIL
+     * Verifier.verify((Character) null).asciiControl() =&gt; FAIL
+     * Verifier.verify('\0').asciiControl()             =&gt; PASS
+     * Verifier.verify('0').asciiControl()              =&gt; FAIL
+     * Verifier.verify('Z').asciiControl()              =&gt; FAIL
+     * Verifier.verify('१').asciiControl()              =&gt; FAIL
+     * Verifier.verify('É').asciiControl()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -291,12 +291,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an ASCII digit.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiNumeric() => FAIL
-     * Verifier.verify('\0').asciiNumeric()             => FAIL
-     * Verifier.verify('0').asciiNumeric()              => PASS
-     * Verifier.verify('Z').asciiNumeric()              => FAIL
-     * Verifier.verify('१').asciiNumeric()              => FAIL
-     * Verifier.verify('É').asciiNumeric()              => FAIL
+     * Verifier.verify((Character) null).asciiNumeric() =&gt; FAIL
+     * Verifier.verify('\0').asciiNumeric()             =&gt; FAIL
+     * Verifier.verify('0').asciiNumeric()              =&gt; PASS
+     * Verifier.verify('Z').asciiNumeric()              =&gt; FAIL
+     * Verifier.verify('१').asciiNumeric()              =&gt; FAIL
+     * Verifier.verify('É').asciiNumeric()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -318,14 +318,14 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is ASCII printable.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).asciiPrintable() => FAIL
-     * Verifier.verify('\0').asciiPrintable()             => FAIL
-     * Verifier.verify('0').asciiPrintable()              => PASS
-     * Verifier.verify('Z').asciiPrintable()              => PASS
-     * Verifier.verify(' ').asciiPrintable()              => PASS
-     * Verifier.verify('~').asciiPrintable()              => PASS
-     * Verifier.verify('१').asciiPrintable()              => FAIL
-     * Verifier.verify('É').asciiPrintable()              => FAIL
+     * Verifier.verify((Character) null).asciiPrintable() =&gt; FAIL
+     * Verifier.verify('\0').asciiPrintable()             =&gt; FAIL
+     * Verifier.verify('0').asciiPrintable()              =&gt; PASS
+     * Verifier.verify('Z').asciiPrintable()              =&gt; PASS
+     * Verifier.verify(' ').asciiPrintable()              =&gt; PASS
+     * Verifier.verify('~').asciiPrintable()              =&gt; PASS
+     * Verifier.verify('१').asciiPrintable()              =&gt; FAIL
+     * Verifier.verify('É').asciiPrintable()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -356,14 +356,14 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is a lower case letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).lowerCase() => FAIL
-     * Verifier.verify('\0').lowerCase()             => FAIL
-     * Verifier.verify('0').lowerCase()              => FAIL
-     * Verifier.verify('a').lowerCase()              => PASS
-     * Verifier.verify('Z').lowerCase()              => FAIL
-     * Verifier.verify('१').lowerCase()              => FAIL
-     * Verifier.verify('é').lowerCase()              => PASS
-     * Verifier.verify('É').lowerCase()              => FAIL
+     * Verifier.verify((Character) null).lowerCase() =&gt; FAIL
+     * Verifier.verify('\0').lowerCase()             =&gt; FAIL
+     * Verifier.verify('0').lowerCase()              =&gt; FAIL
+     * Verifier.verify('a').lowerCase()              =&gt; PASS
+     * Verifier.verify('Z').lowerCase()              =&gt; FAIL
+     * Verifier.verify('१').lowerCase()              =&gt; FAIL
+     * Verifier.verify('é').lowerCase()              =&gt; PASS
+     * Verifier.verify('É').lowerCase()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -386,12 +386,12 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is a digit.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).numeric() => FAIL
-     * Verifier.verify('\0').numeric()             => FAIL
-     * Verifier.verify('0').numeric()              => PASS
-     * Verifier.verify('Z').numeric()              => FAIL
-     * Verifier.verify('१').numeric()              => PASS
-     * Verifier.verify('É').numeric()              => FAIL
+     * Verifier.verify((Character) null).numeric() =&gt; FAIL
+     * Verifier.verify('\0').numeric()             =&gt; FAIL
+     * Verifier.verify('0').numeric()              =&gt; PASS
+     * Verifier.verify('Z').numeric()              =&gt; FAIL
+     * Verifier.verify('१').numeric()              =&gt; PASS
+     * Verifier.verify('É').numeric()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -423,14 +423,14 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is an upper case letter.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).upperCase() => FAIL
-     * Verifier.verify('\0').upperCase()             => FAIL
-     * Verifier.verify('0').upperCase()              => FAIL
-     * Verifier.verify('a').upperCase()              => FAIL
-     * Verifier.verify('Z').upperCase()              => PASS
-     * Verifier.verify('१').upperCase()              => FAIL
-     * Verifier.verify('é').upperCase()              => FAIL
-     * Verifier.verify('É').upperCase()              => PASS
+     * Verifier.verify((Character) null).upperCase() =&gt; FAIL
+     * Verifier.verify('\0').upperCase()             =&gt; FAIL
+     * Verifier.verify('0').upperCase()              =&gt; FAIL
+     * Verifier.verify('a').upperCase()              =&gt; FAIL
+     * Verifier.verify('Z').upperCase()              =&gt; PASS
+     * Verifier.verify('१').upperCase()              =&gt; FAIL
+     * Verifier.verify('é').upperCase()              =&gt; FAIL
+     * Verifier.verify('É').upperCase()              =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.
@@ -453,14 +453,14 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
      * Verifies that the value is whitespace.
      * </p>
      * <pre>
-     * Verifier.verify((Character) null).whitespace() => FAIL
-     * Verifier.verify('\0').whitespace()             => FAIL
-     * Verifier.verify('0').whitespace()              => FAIL
-     * Verifier.verify('Z').whitespace()              => FAIL
-     * Verifier.verify(' ').whitespace()              => PASS
-     * Verifier.verify('\r').whitespace()             => PASS
-     * Verifier.verify('\n').whitespace()             => PASS
-     * Verifier.verify('\t').whitespace()             => PASS
+     * Verifier.verify((Character) null).whitespace() =&gt; FAIL
+     * Verifier.verify('\0').whitespace()             =&gt; FAIL
+     * Verifier.verify('0').whitespace()              =&gt; FAIL
+     * Verifier.verify('Z').whitespace()              =&gt; FAIL
+     * Verifier.verify(' ').whitespace()              =&gt; PASS
+     * Verifier.verify('\r').whitespace()             =&gt; PASS
+     * Verifier.verify('\n').whitespace()             =&gt; PASS
+     * Verifier.verify('\t').whitespace()             =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link CharacterVerifier} for chaining purposes.

--- a/src/main/java/io/skelp/verifier/type/ClassVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ClassVerifier.java
@@ -66,9 +66,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value has at least one annotation of any type.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).annotated()               => FAIL
-     * Verifier.verify(MyAnnotatedObject.class).annotated()    => PASS
-     * Verifier.verify(MyNonAnnotatedObject.class).annotated() => FAIL
+     * Verifier.verify((Class) null).annotated()               =&gt; FAIL
+     * Verifier.verify(MyAnnotatedObject.class).annotated()    =&gt; PASS
+     * Verifier.verify(MyNonAnnotatedObject.class).annotated() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -92,11 +92,11 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).annotatedWith(null)                          => FAIL
-     * Verifier.verify((Class) null).annotatedWith(*)                  => FAIL
-     * Verifier.verify(Object.class).annotatedWith(*)                  => FAIL
-     * Verifier.verify(Override.class).annotatedWith(Documented.class) => FAIL
-     * Verifier.verify(Override.class).annotatedWith(Retention.class)  => PASS
+     * Verifier.verify(*).annotatedWith(null)                          =&gt; FAIL
+     * Verifier.verify((Class) null).annotatedWith(*)                  =&gt; FAIL
+     * Verifier.verify(Object.class).annotatedWith(*)                  =&gt; FAIL
+     * Verifier.verify(Override.class).annotatedWith(Documented.class) =&gt; FAIL
+     * Verifier.verify(Override.class).annotatedWith(Retention.class)  =&gt; PASS
      * </pre>
      *
      * @param type
@@ -122,13 +122,13 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).annotatedWithAll()                                               => PASS
-     * Verifier.verify(*).annotatedWithAll((Class[]) null)                                 => FAIL
-     * Verifier.verify(*).annotatedWithAll(*, null)                                        => FAIL
-     * Verifier.verify((Class) null).annotatedWithAll(*)                                   => FAIL
-     * Verifier.verify(Object.class).annotatedWithAll(*)                                   => FAIL
-     * Verifier.verify(Override.class).annotatedWithAll(Retention.class, Documented.class) => FAIL
-     * Verifier.verify(Override.class).annotatedWithAll(Retention.class, Target.class)     => PASS
+     * Verifier.verify(*).annotatedWithAll()                                               =&gt; PASS
+     * Verifier.verify(*).annotatedWithAll((Class[]) null)                                 =&gt; FAIL
+     * Verifier.verify(*).annotatedWithAll(*, null)                                        =&gt; FAIL
+     * Verifier.verify((Class) null).annotatedWithAll(*)                                   =&gt; FAIL
+     * Verifier.verify(Object.class).annotatedWithAll(*)                                   =&gt; FAIL
+     * Verifier.verify(Override.class).annotatedWithAll(Retention.class, Documented.class) =&gt; FAIL
+     * Verifier.verify(Override.class).annotatedWithAll(Retention.class, Target.class)     =&gt; PASS
      * </pre>
      *
      * @param types
@@ -159,12 +159,12 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).annotatedWithAny()                                               => FAIL
-     * Verifier.verify(*).annotatedWithAny((Class[]) null)                                 => FAIL
-     * Verifier.verify((Class) null).annotatedWithAny(*)                                   => FAIL
-     * Verifier.verify(Object.class).annotatedWithAny(*)                                   => FAIL
-     * Verifier.verify(Override.class).annotatedWithAny(Retention.class, Documented.class) => PASS
-     * Verifier.verify(Override.class).annotatedWithAny(Retention.class, Target.class)     => PASS
+     * Verifier.verify(*).annotatedWithAny()                                               =&gt; FAIL
+     * Verifier.verify(*).annotatedWithAny((Class[]) null)                                 =&gt; FAIL
+     * Verifier.verify((Class) null).annotatedWithAny(*)                                   =&gt; FAIL
+     * Verifier.verify(Object.class).annotatedWithAny(*)                                   =&gt; FAIL
+     * Verifier.verify(Override.class).annotatedWithAny(Retention.class, Documented.class) =&gt; PASS
+     * Verifier.verify(Override.class).annotatedWithAny(Retention.class, Target.class)     =&gt; PASS
      * </pre>
      *
      * @param types
@@ -192,9 +192,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is an annotation.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).annotation()   => FAIL
-     * Verifier.verify(Override.class).annotation() => PASS
-     * Verifier.verify(Verifier.class).annotation() => FAIL
+     * Verifier.verify((Class) null).annotation()   =&gt; FAIL
+     * Verifier.verify(Override.class).annotation() =&gt; PASS
+     * Verifier.verify(Verifier.class).annotation() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -215,9 +215,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is an anonymous type.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).anonymous()                    => FAIL
-     * Verifier.verify(Object.class).anonymous()                    => FAIL
-     * Verifier.verify(new Serializable(){}.getClass()).anonymous() => PASS
+     * Verifier.verify((Class) null).anonymous()                    =&gt; FAIL
+     * Verifier.verify(Object.class).anonymous()                    =&gt; FAIL
+     * Verifier.verify(new Serializable(){}.getClass()).anonymous() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -238,9 +238,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is an array.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).array()   => FAIL
-     * Verifier.verify(Object.class).array()   => FAIL
-     * Verifier.verify(Object[].class).array() => PASS
+     * Verifier.verify((Class) null).array()   =&gt; FAIL
+     * Verifier.verify(Object.class).array()   =&gt; FAIL
+     * Verifier.verify(Object[].class).array() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -265,10 +265,10 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).assignableFrom(null)                      => FAIL
-     * Verifier.verify((Class) null).assignableFrom(*)              => FAIL
-     * Verifier.verify(Object.class).assignableFrom(Verifier.class) => PASS
-     * Verifier.verify(Verifier.class).assignableFrom(Object.class) => FAIL
+     * Verifier.verify(*).assignableFrom(null)                      =&gt; FAIL
+     * Verifier.verify((Class) null).assignableFrom(*)              =&gt; FAIL
+     * Verifier.verify(Object.class).assignableFrom(Verifier.class) =&gt; PASS
+     * Verifier.verify(Verifier.class).assignableFrom(Object.class) =&gt; FAIL
      * </pre>
      *
      * @param type
@@ -291,9 +291,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is an enum.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).enumeration()    => FAIL
-     * Verifier.verify(Object.class).enumeration()    => FAIL
-     * Verifier.verify(DayOfWeek.class).enumeration() => PASS
+     * Verifier.verify((Class) null).enumeration()    =&gt; FAIL
+     * Verifier.verify(Object.class).enumeration()    =&gt; FAIL
+     * Verifier.verify(DayOfWeek.class).enumeration() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -314,9 +314,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is an interface.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).interfacing()       => FAIL
-     * Verifier.verify(Object.class).interfacing()       => FAIL
-     * Verifier.verify(Serializable.class).interfacing() => PASS
+     * Verifier.verify((Class) null).interfacing()       =&gt; FAIL
+     * Verifier.verify(Object.class).interfacing()       =&gt; FAIL
+     * Verifier.verify(Serializable.class).interfacing() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -337,9 +337,9 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is nested.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).nested()           => FAIL
-     * Verifier.verify(Calendar.class).nested()         => FAIL
-     * Verifier.verify(Calendar.Builder.class).nested() => PASS
+     * Verifier.verify((Class) null).nested()           =&gt; FAIL
+     * Verifier.verify(Calendar.class).nested()         =&gt; FAIL
+     * Verifier.verify(Calendar.Builder.class).nested() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -360,10 +360,10 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is a primitive.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).primitive()  => FAIL
-     * Verifier.verify(Object.class).primitive()  => FAIL
-     * Verifier.verify(Boolean.class).primitive() => FAIL
-     * Verifier.verify(Boolean.TYPE).primitive()  => PASS
+     * Verifier.verify((Class) null).primitive()  =&gt; FAIL
+     * Verifier.verify(Object.class).primitive()  =&gt; FAIL
+     * Verifier.verify(Boolean.class).primitive() =&gt; FAIL
+     * Verifier.verify(Boolean.TYPE).primitive()  =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -384,10 +384,10 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is a primitive or primitive wrapper.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).primitiveOrWrapper()  => FAIL
-     * Verifier.verify(Object.class).primitiveOrWrapper()  => FAIL
-     * Verifier.verify(Boolean.class).primitiveOrWrapper() => PASS
-     * Verifier.verify(Boolean.TYPE).primitiveOrWrapper()  => PASS
+     * Verifier.verify((Class) null).primitiveOrWrapper()  =&gt; FAIL
+     * Verifier.verify(Object.class).primitiveOrWrapper()  =&gt; FAIL
+     * Verifier.verify(Boolean.class).primitiveOrWrapper() =&gt; PASS
+     * Verifier.verify(Boolean.TYPE).primitiveOrWrapper()  =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.
@@ -408,10 +408,10 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
      * Verifies that the value is a primitive wrapper.
      * </p>
      * <pre>
-     * Verifier.verify((Class) null).primitiveWrapper()  => FAIL
-     * Verifier.verify(Object.class).primitiveWrapper()  => FAIL
-     * Verifier.verify(Boolean.class).primitiveWrapper() => PASS
-     * Verifier.verify(Boolean.TYPE).primitiveWrapper()  => FAIL
+     * Verifier.verify((Class) null).primitiveWrapper()  =&gt; FAIL
+     * Verifier.verify(Object.class).primitiveWrapper()  =&gt; FAIL
+     * Verifier.verify(Boolean.class).primitiveWrapper() =&gt; PASS
+     * Verifier.verify(Boolean.TYPE).primitiveWrapper()  =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link ClassVerifier} for chaining purposes.

--- a/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
@@ -58,9 +58,9 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * Verifies that the value is an available {@code Locale}.
      * </p>
      * <pre>
-     * Verifier.verify((Locale) null).available()            => FAIL
-     * Verifier.verify(Locale.US).available()                => PASS
-     * Verifier.verify(new Locale("foo", "BAR")).available() => FAIL
+     * Verifier.verify((Locale) null).available()            =&gt; FAIL
+     * Verifier.verify(Locale.US).available()                =&gt; PASS
+     * Verifier.verify(new Locale("foo", "BAR")).available() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link LocaleVerifier} for chaining purposes.
@@ -84,11 +84,11 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).country(null)                      => FAIL
-     * Verifier.verify((Locale) null).country(*)             => FAIL
-     * Verifier.verify(new Locale("en", "")).country("")     => PASS
-     * Verifier.verify(new Locale("en", "US")).country("GB") => FAIL
-     * Verifier.verify(new Locale("en", "US")).country("US") => PASS
+     * Verifier.verify(*).country(null)                      =&gt; FAIL
+     * Verifier.verify((Locale) null).country(*)             =&gt; FAIL
+     * Verifier.verify(new Locale("en", "")).country("")     =&gt; PASS
+     * Verifier.verify(new Locale("en", "US")).country("GB") =&gt; FAIL
+     * Verifier.verify(new Locale("en", "US")).country("US") =&gt; PASS
      * </pre>
      *
      * @param country
@@ -111,9 +111,9 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * Verifies that the value is the default {@code Locale}.
      * </p>
      * <pre>
-     * Verifier.verify((Locale) null).defaulting()            => FAIL
-     * Verifier.verify(Locale.getDefault()).defaulting()      => PASS
-     * Verifier.verify(new Locale("foo", "BAR")).defaulting() => FAIL
+     * Verifier.verify((Locale) null).defaulting()            =&gt; FAIL
+     * Verifier.verify(Locale.getDefault()).defaulting()      =&gt; PASS
+     * Verifier.verify(new Locale("foo", "BAR")).defaulting() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link LocaleVerifier} for chaining purposes.
@@ -137,10 +137,10 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).language(null)                      => FAIL
-     * Verifier.verify((Locale) null).language(*)             => FAIL
-     * Verifier.verify(new Locale("en", "US")).language("fr") => FAIL
-     * Verifier.verify(new Locale("en", "US")).language("en") => PASS
+     * Verifier.verify(*).language(null)                      =&gt; FAIL
+     * Verifier.verify((Locale) null).language(*)             =&gt; FAIL
+     * Verifier.verify(new Locale("en", "US")).language("fr") =&gt; FAIL
+     * Verifier.verify(new Locale("en", "US")).language("en") =&gt; PASS
      * </pre>
      *
      * @param language
@@ -166,11 +166,11 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).script(null)                    => FAIL
-     * Verifier.verify((Locale) null).script(*)           => FAIL
-     * Verifier.verify(new Locale("en", "US")).script("") => PASS
-     * Verifier.verify(latinLocale).script("Arab")        => FAIL
-     * Verifier.verify(latinLocale).script("Latn")        => PASS
+     * Verifier.verify(*).script(null)                    =&gt; FAIL
+     * Verifier.verify((Locale) null).script(*)           =&gt; FAIL
+     * Verifier.verify(new Locale("en", "US")).script("") =&gt; PASS
+     * Verifier.verify(latinLocale).script("Arab")        =&gt; FAIL
+     * Verifier.verify(latinLocale).script("Latn")        =&gt; PASS
      * </pre>
      *
      * @param script
@@ -196,11 +196,11 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).variant(null)                                        => FAIL
-     * Verifier.verify((Locale) null).variant(*)                               => FAIL
-     * Verifier.verify(new Locale("en", "GB")).variant("")                     => PASS
-     * Verifier.verify(new Locale("en", "GB", "scotland")).variant("scouse")   => FAIL
-     * Verifier.verify(new Locale("en", "GB", "scotland")).variant("scotland") => PASS
+     * Verifier.verify(*).variant(null)                                        =&gt; FAIL
+     * Verifier.verify((Locale) null).variant(*)                               =&gt; FAIL
+     * Verifier.verify(new Locale("en", "GB")).variant("")                     =&gt; PASS
+     * Verifier.verify(new Locale("en", "GB", "scotland")).variant("scouse")   =&gt; FAIL
+     * Verifier.verify(new Locale("en", "GB", "scotland")).variant("scotland") =&gt; PASS
      * </pre>
      *
      * @param variant

--- a/src/main/java/io/skelp/verifier/type/MapVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/MapVerifier.java
@@ -63,14 +63,14 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Map) null).containAllKeys(*)                                                       => FAIL
-     * Verifier.verify(map(new Object[0][])).containAllKeys(*)                                             => FAIL
-     * Verifier.verify(map(new Object[][]{*})).containAllKeys((Object[]) null)                             => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("d", "e")   => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("a", "d")   => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("c", "b")   => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("c", null)  => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containAllKeys("a", null) => PASS
+     * Verifier.verify((Map) null).containAllKeys(*)                                                       =&gt; FAIL
+     * Verifier.verify(map(new Object[0][])).containAllKeys(*)                                             =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{*})).containAllKeys((Object[]) null)                             =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("d", "e")   =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("a", "d")   =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("c", "b")   =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAllKeys("c", null)  =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containAllKeys("a", null) =&gt; PASS
      * </pre>
      *
      * @param keys
@@ -101,14 +101,14 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Map) null).containAnyKey(*)                                                       => FAIL
-     * Verifier.verify(map(new Object[0][])).containAnyKey(*)                                             => FAIL
-     * Verifier.verify(map(new Object[][]{*})).containAnyKey((Object[]) null)                             => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("d", "e")   => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("a", "d")   => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("c", "b")   => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("c", null)  => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containAnyKey("d", null) => PASS
+     * Verifier.verify((Map) null).containAnyKey(*)                                                       =&gt; FAIL
+     * Verifier.verify(map(new Object[0][])).containAnyKey(*)                                             =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{*})).containAnyKey((Object[]) null)                             =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("d", "e")   =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("a", "d")   =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("c", "b")   =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containAnyKey("c", null)  =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containAnyKey("d", null) =&gt; PASS
      * </pre>
      *
      * @param keys
@@ -139,12 +139,12 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Map) null).containKey(*)                                                  => FAIL
-     * Verifier.verify(map(new Object[0][])).containKey(*)                                        => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey("c")   => PASS
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey("d")   => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey(null)  => FAIL
-     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containKey(null) => PASS
+     * Verifier.verify((Map) null).containKey(*)                                                  =&gt; FAIL
+     * Verifier.verify(map(new Object[0][])).containKey(*)                                        =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey("c")   =&gt; PASS
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey("d")   =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {"c", 789}})).containKey(null)  =&gt; FAIL
+     * Verifier.verify(map(new Object[][]{{"a", 123}, {"b", 456}, {null, 789}})).containKey(null) =&gt; PASS
      * </pre>
      *
      * @param key

--- a/src/main/java/io/skelp/verifier/type/StringVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/StringVerifier.java
@@ -137,12 +137,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only letters.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).alpha() => FAIL
-     * Verifier.verify("\0\r\n").alpha()      => FAIL
-     * Verifier.verify("123").alpha()         => FAIL
-     * Verifier.verify("abc").alpha()         => PASS
-     * Verifier.verify("abc123").alpha()      => FAIL
-     * Verifier.verify("a b c").alpha()       => FAIL
+     * Verifier.verify((String) null).alpha() =&gt; FAIL
+     * Verifier.verify("\0\r\n").alpha()      =&gt; FAIL
+     * Verifier.verify("123").alpha()         =&gt; FAIL
+     * Verifier.verify("abc").alpha()         =&gt; PASS
+     * Verifier.verify("abc123").alpha()      =&gt; FAIL
+     * Verifier.verify("a b c").alpha()       =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -169,11 +169,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only letters or space.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).alphaSpace() => FAIL
-     * Verifier.verify("\0 \r \n").alphaSpace()    => FAIL
-     * Verifier.verify("1 2 3").alphaSpace()       => FAIL
-     * Verifier.verify("a b c").alphaSpace()       => PASS
-     * Verifier.verify("a b c 1 2 3").alphaSpace() => FAIL
+     * Verifier.verify((String) null).alphaSpace() =&gt; FAIL
+     * Verifier.verify("\0 \r \n").alphaSpace()    =&gt; FAIL
+     * Verifier.verify("1 2 3").alphaSpace()       =&gt; FAIL
+     * Verifier.verify("a b c").alphaSpace()       =&gt; PASS
+     * Verifier.verify("a b c 1 2 3").alphaSpace() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -200,12 +200,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only letters or digits.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).alphanumeric() => FAIL
-     * Verifier.verify("\0\r\n").alphanumeric()      => FAIL
-     * Verifier.verify("123").alphanumeric()         => PASS
-     * Verifier.verify("abc").alphanumeric()         => PASS
-     * Verifier.verify("abc123").alphanumeric()      => PASS
-     * Verifier.verify("a b c 1 2 3").alphanumeric() => FAIL
+     * Verifier.verify((String) null).alphanumeric() =&gt; FAIL
+     * Verifier.verify("\0\r\n").alphanumeric()      =&gt; FAIL
+     * Verifier.verify("123").alphanumeric()         =&gt; PASS
+     * Verifier.verify("abc").alphanumeric()         =&gt; PASS
+     * Verifier.verify("abc123").alphanumeric()      =&gt; PASS
+     * Verifier.verify("a b c 1 2 3").alphanumeric() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -232,11 +232,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only letters or digits or space.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).alphanumericSpace() => FAIL
-     * Verifier.verify("\0 \r \n").alphanumericSpace()    => FAIL
-     * Verifier.verify("1 2 3").alphanumericSpace()       => PASS
-     * Verifier.verify("a b c").alphanumericSpace()       => PASS
-     * Verifier.verify("a b c 1 2 3").alphanumericSpace() => PASS
+     * Verifier.verify((String) null).alphanumericSpace() =&gt; FAIL
+     * Verifier.verify("\0 \r \n").alphanumericSpace()    =&gt; FAIL
+     * Verifier.verify("1 2 3").alphanumericSpace()       =&gt; PASS
+     * Verifier.verify("a b c").alphanumericSpace()       =&gt; PASS
+     * Verifier.verify("a b c 1 2 3").alphanumericSpace() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -263,10 +263,10 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value only contains ASCII printable characters.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).asciiPrintable() => FAIL
-     * Verifier.verify("\0 abc").asciiPrintable()      => FAIL
-     * Verifier.verify("abc ~ 123").asciiPrintable()   => PASS
-     * Verifier.verify("É १").asciiPrintable()         => FAIL
+     * Verifier.verify((String) null).asciiPrintable() =&gt; FAIL
+     * Verifier.verify("\0 abc").asciiPrintable()      =&gt; FAIL
+     * Verifier.verify("abc ~ 123").asciiPrintable()   =&gt; PASS
+     * Verifier.verify("É १").asciiPrintable()         =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -295,13 +295,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).blank() => PASS
-     * Verifier.verify("abc 123").blank()     => FAIL
-     * Verifier.verify("  abc 123  ").blank() => FAIL
-     * Verifier.verify("  \r\nabc").blank()   => FAIL
-     * Verifier.verify("").blank()            => PASS
-     * Verifier.verify("  ").blank()          => PASS
-     * Verifier.verify("\r\n\t").blank()      => PASS
+     * Verifier.verify((String) null).blank() =&gt; PASS
+     * Verifier.verify("abc 123").blank()     =&gt; FAIL
+     * Verifier.verify("  abc 123  ").blank() =&gt; FAIL
+     * Verifier.verify("  \r\nabc").blank()   =&gt; FAIL
+     * Verifier.verify("").blank()            =&gt; PASS
+     * Verifier.verify("  ").blank()          =&gt; PASS
+     * Verifier.verify("\r\n\t").blank()      =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -326,13 +326,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).contain(*)             => FAIL
-     * Verifier.verify(*).contain(null)                      => FAIL
-     * Verifier.verify(*).contain("")                        => PASS
-     * Verifier.verify("abc def 123").contain("ghi")         => FAIL
-     * Verifier.verify("abc def 123").contain("def")         => PASS
-     * Verifier.verify("abc def 123").contain("abc def 123") => PASS
-     * Verifier.verify("abc def 123").contain("DEF")         => FAIL
+     * Verifier.verify((String) null).contain(*)             =&gt; FAIL
+     * Verifier.verify(*).contain(null)                      =&gt; FAIL
+     * Verifier.verify(*).contain("")                        =&gt; PASS
+     * Verifier.verify("abc def 123").contain("ghi")         =&gt; FAIL
+     * Verifier.verify("abc def 123").contain("def")         =&gt; PASS
+     * Verifier.verify("abc def 123").contain("abc def 123") =&gt; PASS
+     * Verifier.verify("abc def 123").contain("DEF")         =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -359,12 +359,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).containAll(*)            => FAIL
-     * Verifier.verify(*).containAll((CharSequence[]) null)    => PASS
-     * Verifier.verify("abc def 123").containAll("ghi", "456") => FAIL
-     * Verifier.verify("abc def 123").containAll("def", "456") => FAIL
-     * Verifier.verify("abc def 123").containAll("123", "def") => PASS
-     * Verifier.verify("abc def 123").containAll("123", "ABC") => FAIL
+     * Verifier.verify((String) null).containAll(*)            =&gt; FAIL
+     * Verifier.verify(*).containAll((CharSequence[]) null)    =&gt; PASS
+     * Verifier.verify("abc def 123").containAll("ghi", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAll("def", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAll("123", "def") =&gt; PASS
+     * Verifier.verify("abc def 123").containAll("123", "ABC") =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -396,12 +396,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).containAllIgnoreCase(*)            => FAIL
-     * Verifier.verify(*).containAllIgnoreCase((CharSequence[]) null)    => PASS
-     * Verifier.verify("abc def 123").containAllIgnoreCase("ghi", "456") => FAIL
-     * Verifier.verify("abc def 123").containAllIgnoreCase("def", "456") => FAIL
-     * Verifier.verify("abc def 123").containAllIgnoreCase("123", "def") => PASS
-     * Verifier.verify("abc def 123").containAllIgnoreCase("123", "DEF") => PASS
+     * Verifier.verify((String) null).containAllIgnoreCase(*)            =&gt; FAIL
+     * Verifier.verify(*).containAllIgnoreCase((CharSequence[]) null)    =&gt; PASS
+     * Verifier.verify("abc def 123").containAllIgnoreCase("ghi", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAllIgnoreCase("def", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAllIgnoreCase("123", "def") =&gt; PASS
+     * Verifier.verify("abc def 123").containAllIgnoreCase("123", "DEF") =&gt; PASS
      * </pre>
      *
      * @param others
@@ -433,13 +433,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).containAny(*)            => FAIL
-     * Verifier.verify(*).containAny((CharSequence[]) null)    => FAIL
-     * Verifier.verify(*).containAny("", *)                    => PASS
-     * Verifier.verify("abc def 123").containAny("ghi", "456") => FAIL
-     * Verifier.verify("abc def 123").containAny("def", "456") => PASS
-     * Verifier.verify("abc def 123").containAny("123", "def") => PASS
-     * Verifier.verify("abc def 123").containAny("DEF", "456") => FAIL
+     * Verifier.verify((String) null).containAny(*)            =&gt; FAIL
+     * Verifier.verify(*).containAny((CharSequence[]) null)    =&gt; FAIL
+     * Verifier.verify(*).containAny("", *)                    =&gt; PASS
+     * Verifier.verify("abc def 123").containAny("ghi", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAny("def", "456") =&gt; PASS
+     * Verifier.verify("abc def 123").containAny("123", "def") =&gt; PASS
+     * Verifier.verify("abc def 123").containAny("DEF", "456") =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -471,13 +471,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).containAnyIgnoreCase(*)            => FAIL
-     * Verifier.verify(*).containAnyIgnoreCase((CharSequence[]) null)    => FAIL
-     * Verifier.verify(*).containAnyIgnoreCase("", *)                    => PASS
-     * Verifier.verify("abc def 123").containAnyIgnoreCase("ghi", "456") => FAIL
-     * Verifier.verify("abc def 123").containAnyIgnoreCase("def", "456") => PASS
-     * Verifier.verify("abc def 123").containAnyIgnoreCase("123", "def") => PASS
-     * Verifier.verify("abc def 123").containAnyIgnoreCase("DEF", "456") => PASS
+     * Verifier.verify((String) null).containAnyIgnoreCase(*)            =&gt; FAIL
+     * Verifier.verify(*).containAnyIgnoreCase((CharSequence[]) null)    =&gt; FAIL
+     * Verifier.verify(*).containAnyIgnoreCase("", *)                    =&gt; PASS
+     * Verifier.verify("abc def 123").containAnyIgnoreCase("ghi", "456") =&gt; FAIL
+     * Verifier.verify("abc def 123").containAnyIgnoreCase("def", "456") =&gt; PASS
+     * Verifier.verify("abc def 123").containAnyIgnoreCase("123", "def") =&gt; PASS
+     * Verifier.verify("abc def 123").containAnyIgnoreCase("DEF", "456") =&gt; PASS
      * </pre>
      *
      * @param others
@@ -509,13 +509,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).containIgnoreCase(*)             => FAIL
-     * Verifier.verify(*).containIgnoreCase(null)                      => FAIL
-     * Verifier.verify(*).containIgnoreCase("")                        => PASS
-     * Verifier.verify("abc def 123").containIgnoreCase("ghi")         => FAIL
-     * Verifier.verify("abc def 123").containIgnoreCase("def")         => PASS
-     * Verifier.verify("abc def 123").containIgnoreCase("abc def 123") => PASS
-     * Verifier.verify("abc def 123").containIgnoreCase("DEF")         => PASS
+     * Verifier.verify((String) null).containIgnoreCase(*)             =&gt; FAIL
+     * Verifier.verify(*).containIgnoreCase(null)                      =&gt; FAIL
+     * Verifier.verify(*).containIgnoreCase("")                        =&gt; PASS
+     * Verifier.verify("abc def 123").containIgnoreCase("ghi")         =&gt; FAIL
+     * Verifier.verify("abc def 123").containIgnoreCase("def")         =&gt; PASS
+     * Verifier.verify("abc def 123").containIgnoreCase("abc def 123") =&gt; PASS
+     * Verifier.verify("abc def 123").containIgnoreCase("DEF")         =&gt; PASS
      * </pre>
      *
      * @param other
@@ -542,11 +542,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).empty() => PASS
-     * Verifier.verify("abc 123").empty()     => FAIL
-     * Verifier.verify("").empty()            => PASS
-     * Verifier.verify("  ").empty()          => FAIL
-     * Verifier.verify("\r\n\t").empty()      => FAIL
+     * Verifier.verify((String) null).empty() =&gt; PASS
+     * Verifier.verify("abc 123").empty()     =&gt; FAIL
+     * Verifier.verify("").empty()            =&gt; PASS
+     * Verifier.verify("  ").empty()          =&gt; FAIL
+     * Verifier.verify("\r\n\t").empty()      =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -571,13 +571,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).endWith(*)     => FAIL
-     * Verifier.verify(*).endWith(null)              => FAIL
-     * Verifier.verify(*).endWith("")                => PASS
-     * Verifier.verify("abc def").endWith("abc")     => FAIL
-     * Verifier.verify("abc def").endWith("def")     => PASS
-     * Verifier.verify("abc def").endWith("abc def") => PASS
-     * Verifier.verify("abc def").endWith("DEF")     => FAIL
+     * Verifier.verify((String) null).endWith(*)     =&gt; FAIL
+     * Verifier.verify(*).endWith(null)              =&gt; FAIL
+     * Verifier.verify(*).endWith("")                =&gt; PASS
+     * Verifier.verify("abc def").endWith("abc")     =&gt; FAIL
+     * Verifier.verify("abc def").endWith("def")     =&gt; PASS
+     * Verifier.verify("abc def").endWith("abc def") =&gt; PASS
+     * Verifier.verify("abc def").endWith("DEF")     =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -604,12 +604,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).endWithAny(*)         => FAIL
-     * Verifier.verify(*).endWithAny((CharSequence[]) null) => FAIL
-     * Verifier.verify(*).endWithAny("", *)                 => PASS
-     * Verifier.verify("abc def").endWithAny("ghi", "123")  => FAIL
-     * Verifier.verify("abc def").endWithAny("def", "123")  => PASS
-     * Verifier.verify("abc def").endWithAny("DEF", "123")  => FAIL
+     * Verifier.verify((String) null).endWithAny(*)         =&gt; FAIL
+     * Verifier.verify(*).endWithAny((CharSequence[]) null) =&gt; FAIL
+     * Verifier.verify(*).endWithAny("", *)                 =&gt; PASS
+     * Verifier.verify("abc def").endWithAny("ghi", "123")  =&gt; FAIL
+     * Verifier.verify("abc def").endWithAny("def", "123")  =&gt; PASS
+     * Verifier.verify("abc def").endWithAny("DEF", "123")  =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -641,12 +641,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).endWithAnyIgnoreCase(*)         => FAIL
-     * Verifier.verify(*).endWithAnyIgnoreCase((CharSequence[]) null) => FAIL
-     * Verifier.verify(*).endWithAnyIgnoreCase("", *)                 => PASS
-     * Verifier.verify("abc def").endWithAnyIgnoreCase("ghi", "123")  => FAIL
-     * Verifier.verify("abc def").endWithAnyIgnoreCase("def", "123")  => PASS
-     * Verifier.verify("abc def").endWithAnyIgnoreCase("DEF", "123")  => PASS
+     * Verifier.verify((String) null).endWithAnyIgnoreCase(*)         =&gt; FAIL
+     * Verifier.verify(*).endWithAnyIgnoreCase((CharSequence[]) null) =&gt; FAIL
+     * Verifier.verify(*).endWithAnyIgnoreCase("", *)                 =&gt; PASS
+     * Verifier.verify("abc def").endWithAnyIgnoreCase("ghi", "123")  =&gt; FAIL
+     * Verifier.verify("abc def").endWithAnyIgnoreCase("def", "123")  =&gt; PASS
+     * Verifier.verify("abc def").endWithAnyIgnoreCase("DEF", "123")  =&gt; PASS
      * </pre>
      *
      * @param others
@@ -678,13 +678,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).endWithIgnoreCase(*)     => FAIL
-     * Verifier.verify(*).endWithIgnoreCase(null)              => FAIL
-     * Verifier.verify(*).endWithIgnoreCase("")                => PASS
-     * Verifier.verify("abc def").endWithIgnoreCase("abc")     => FAIL
-     * Verifier.verify("abc def").endWithIgnoreCase("def")     => PASS
-     * Verifier.verify("abc def").endWithIgnoreCase("abc def") => PASS
-     * Verifier.verify("abc def").endWithIgnoreCase("DEF")     => PASS
+     * Verifier.verify((String) null).endWithIgnoreCase(*)     =&gt; FAIL
+     * Verifier.verify(*).endWithIgnoreCase(null)              =&gt; FAIL
+     * Verifier.verify(*).endWithIgnoreCase("")                =&gt; PASS
+     * Verifier.verify("abc def").endWithIgnoreCase("abc")     =&gt; FAIL
+     * Verifier.verify("abc def").endWithIgnoreCase("def")     =&gt; PASS
+     * Verifier.verify("abc def").endWithIgnoreCase("abc def") =&gt; PASS
+     * Verifier.verify("abc def").endWithIgnoreCase("DEF")     =&gt; PASS
      * </pre>
      *
      * @param other
@@ -711,13 +711,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).equalToAnyIgnoreCase()                                => FAIL
-     * Verifier.verify(*).equalToAnyIgnoreCase((CharSequence[]) null)           => FAIL
-     * Verifier.verify((String) null).equalToAnyIgnoreCase("ghi", "def", null)  => PASS
-     * Verifier.verify((String) null).equalToAnyIgnoreCase("ghi", "def", "abc") => FAIL
-     * Verifier.verify("abc").equalToAnyIgnoreCase("ghi", "def", null)          => FAIL
-     * Verifier.verify("abc").equalToAnyIgnoreCase("ghi", "def", "abc")         => PASS
-     * Verifier.verify("abc").equalToAnyIgnoreCase("GHI", "DEF", "ABC")         => PASS
+     * Verifier.verify(*).equalToAnyIgnoreCase()                                =&gt; FAIL
+     * Verifier.verify(*).equalToAnyIgnoreCase((CharSequence[]) null)           =&gt; FAIL
+     * Verifier.verify((String) null).equalToAnyIgnoreCase("ghi", "def", null)  =&gt; PASS
+     * Verifier.verify((String) null).equalToAnyIgnoreCase("ghi", "def", "abc") =&gt; FAIL
+     * Verifier.verify("abc").equalToAnyIgnoreCase("ghi", "def", null)          =&gt; FAIL
+     * Verifier.verify("abc").equalToAnyIgnoreCase("ghi", "def", "abc")         =&gt; PASS
+     * Verifier.verify("abc").equalToAnyIgnoreCase("GHI", "DEF", "ABC")         =&gt; PASS
      * </pre>
      *
      * @param others
@@ -750,12 +750,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).equalToIgnoreCase(null)  => PASS
-     * Verifier.verify((String) null).equalToIgnoreCase("abc") => FAIL
-     * Verifier.verify("abc").equalToIgnoreCase(null)          => FAIL
-     * Verifier.verify("abc").equalToIgnoreCase("abc")         => PASS
-     * Verifier.verify("abc").equalToIgnoreCase("ABC")         => PASS
-     * Verifier.verify("abc").equalToIgnoreCase("def")         => FAIL
+     * Verifier.verify((String) null).equalToIgnoreCase(null)  =&gt; PASS
+     * Verifier.verify((String) null).equalToIgnoreCase("abc") =&gt; FAIL
+     * Verifier.verify("abc").equalToIgnoreCase(null)          =&gt; FAIL
+     * Verifier.verify("abc").equalToIgnoreCase("abc")         =&gt; PASS
+     * Verifier.verify("abc").equalToIgnoreCase("ABC")         =&gt; PASS
+     * Verifier.verify("abc").equalToIgnoreCase("def")         =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -789,12 +789,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only lower case letters.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).lowerCase() => FAIL
-     * Verifier.verify("ABC").lowerCase()         => FAIL
-     * Verifier.verify("abcDEF").lowerCase()      => FAIL
-     * Verifier.verify("abc123").lowerCase()      => FAIL
-     * Verifier.verify("abc").lowerCase()         => PASS
-     * Verifier.verify("a b c").lowerCase()       => FAIL
+     * Verifier.verify((String) null).lowerCase() =&gt; FAIL
+     * Verifier.verify("ABC").lowerCase()         =&gt; FAIL
+     * Verifier.verify("abcDEF").lowerCase()      =&gt; FAIL
+     * Verifier.verify("abc123").lowerCase()      =&gt; FAIL
+     * Verifier.verify("abc").lowerCase()         =&gt; PASS
+     * Verifier.verify("a b c").lowerCase()       =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -824,11 +824,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).match(*)       => FAIL
-     * Verifier.verify(*).match((CharSequence) null) => FAIL
-     * Verifier.verify(*).match(".*")                => PASS
-     * Verifier.verify("foo").match("fo{2}")         => PASS
-     * Verifier.verify("food").match("fo{2}")        => FAIL
+     * Verifier.verify((String) null).match(*)       =&gt; FAIL
+     * Verifier.verify(*).match((CharSequence) null) =&gt; FAIL
+     * Verifier.verify(*).match(".*")                =&gt; PASS
+     * Verifier.verify("foo").match("fo{2}")         =&gt; PASS
+     * Verifier.verify("food").match("fo{2}")        =&gt; FAIL
      * </pre>
      *
      * @param regex
@@ -855,11 +855,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).match(*)                 => FAIL
-     * Verifier.verify(*).match((Pattern) null)                => FAIL
-     * Verifier.verify(*).match(Pattern.compile(".*"))         => PASS
-     * Verifier.verify("foo").match(Pattern.compile("fo{2}"))  => PASS
-     * Verifier.verify("food").match(Pattern.compile("fo{2}")) => FAIL
+     * Verifier.verify((String) null).match(*)                 =&gt; FAIL
+     * Verifier.verify(*).match((Pattern) null)                =&gt; FAIL
+     * Verifier.verify(*).match(Pattern.compile(".*"))         =&gt; PASS
+     * Verifier.verify("foo").match(Pattern.compile("fo{2}"))  =&gt; PASS
+     * Verifier.verify("food").match(Pattern.compile("fo{2}")) =&gt; FAIL
      * </pre>
      *
      * @param pattern
@@ -883,12 +883,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only digits.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).numeric() => FAIL
-     * Verifier.verify("\0\r\n").numeric()      => FAIL
-     * Verifier.verify("123").numeric()         => PASS
-     * Verifier.verify("abc").numeric()         => FAIL
-     * Verifier.verify("abc123").numeric()      => FAIL
-     * Verifier.verify("1 2 3").numeric()       => FAIL
+     * Verifier.verify((String) null).numeric() =&gt; FAIL
+     * Verifier.verify("\0\r\n").numeric()      =&gt; FAIL
+     * Verifier.verify("123").numeric()         =&gt; PASS
+     * Verifier.verify("abc").numeric()         =&gt; FAIL
+     * Verifier.verify("abc123").numeric()      =&gt; FAIL
+     * Verifier.verify("1 2 3").numeric()       =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -915,11 +915,11 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only digits or space.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).numericSpace() => FAIL
-     * Verifier.verify("\0 \r \n").numericSpace()    => FAIL
-     * Verifier.verify("1 2 3").numericSpace()       => PASS
-     * Verifier.verify("a b c").numericSpace()       => FAIL
-     * Verifier.verify("a b c 1 2 3").numericSpace() => FAIL
+     * Verifier.verify((String) null).numericSpace() =&gt; FAIL
+     * Verifier.verify("\0 \r \n").numericSpace()    =&gt; FAIL
+     * Verifier.verify("1 2 3").numericSpace()       =&gt; PASS
+     * Verifier.verify("a b c").numericSpace()       =&gt; FAIL
+     * Verifier.verify("a b c 1 2 3").numericSpace() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.
@@ -949,13 +949,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).sizeOf(1) => FAIL
-     * Verifier.verify((String) null).sizeOf(0) => PASS
-     * Verifier.verify("").sizeOf(1)            => FAIL
-     * Verifier.verify("").sizeOf(0)            => PASS
-     * Verifier.verify(" ").sizeOf(1)           => PASS
-     * Verifier.verify("abc 123").sizeOf(0)     => FAIL
-     * Verifier.verify("abc 123").sizeOf(7)     => PASS
+     * Verifier.verify((String) null).sizeOf(1) =&gt; FAIL
+     * Verifier.verify((String) null).sizeOf(0) =&gt; PASS
+     * Verifier.verify("").sizeOf(1)            =&gt; FAIL
+     * Verifier.verify("").sizeOf(0)            =&gt; PASS
+     * Verifier.verify(" ").sizeOf(1)           =&gt; PASS
+     * Verifier.verify("abc 123").sizeOf(0)     =&gt; FAIL
+     * Verifier.verify("abc 123").sizeOf(7)     =&gt; PASS
      * </pre>
      *
      * @param size
@@ -981,13 +981,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).startWith(*)     => FAIL
-     * Verifier.verify(*).startWith(null)              => FAIL
-     * Verifier.verify(*).startWith("")                => PASS
-     * Verifier.verify("abc def").startWith("abc")     => PASS
-     * Verifier.verify("abc def").startWith("def")     => FAIL
-     * Verifier.verify("abc def").startWith("abc def") => PASS
-     * Verifier.verify("abc def").startWith("ABC")     => FAIL
+     * Verifier.verify((String) null).startWith(*)     =&gt; FAIL
+     * Verifier.verify(*).startWith(null)              =&gt; FAIL
+     * Verifier.verify(*).startWith("")                =&gt; PASS
+     * Verifier.verify("abc def").startWith("abc")     =&gt; PASS
+     * Verifier.verify("abc def").startWith("def")     =&gt; FAIL
+     * Verifier.verify("abc def").startWith("abc def") =&gt; PASS
+     * Verifier.verify("abc def").startWith("ABC")     =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -1014,12 +1014,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).startWithAny(*)         => FAIL
-     * Verifier.verify(*).startWithAny((CharSequence[]) null) => FAIL
-     * Verifier.verify(*).startWithAny("", *)                 => PASS
-     * Verifier.verify("abc def").startWithAny("ghi", "123")  => FAIL
-     * Verifier.verify("abc def").startWithAny("abc", "123")  => PASS
-     * Verifier.verify("abc def").startWithAny("ABC", "123")  => FAIL
+     * Verifier.verify((String) null).startWithAny(*)         =&gt; FAIL
+     * Verifier.verify(*).startWithAny((CharSequence[]) null) =&gt; FAIL
+     * Verifier.verify(*).startWithAny("", *)                 =&gt; PASS
+     * Verifier.verify("abc def").startWithAny("ghi", "123")  =&gt; FAIL
+     * Verifier.verify("abc def").startWithAny("abc", "123")  =&gt; PASS
+     * Verifier.verify("abc def").startWithAny("ABC", "123")  =&gt; FAIL
      * </pre>
      *
      * @param others
@@ -1051,12 +1051,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).startWithAnyIgnoreCase(*)         => FAIL
-     * Verifier.verify(*).startWithAnyIgnoreCase((CharSequence[]) null) => FAIL
-     * Verifier.verify(*).startWithAnyIgnoreCase("", *)                 => PASS
-     * Verifier.verify("abc def").startWithAnyIgnoreCase("ghi", "123")  => FAIL
-     * Verifier.verify("abc def").startWithAnyIgnoreCase("abc", "123")  => PASS
-     * Verifier.verify("abc def").startWithAnyIgnoreCase("ABC", "123")  => PASS
+     * Verifier.verify((String) null).startWithAnyIgnoreCase(*)         =&gt; FAIL
+     * Verifier.verify(*).startWithAnyIgnoreCase((CharSequence[]) null) =&gt; FAIL
+     * Verifier.verify(*).startWithAnyIgnoreCase("", *)                 =&gt; PASS
+     * Verifier.verify("abc def").startWithAnyIgnoreCase("ghi", "123")  =&gt; FAIL
+     * Verifier.verify("abc def").startWithAnyIgnoreCase("abc", "123")  =&gt; PASS
+     * Verifier.verify("abc def").startWithAnyIgnoreCase("ABC", "123")  =&gt; PASS
      * </pre>
      *
      * @param others
@@ -1088,13 +1088,13 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).startWithIgnoreCase(*)     => FAIL
-     * Verifier.verify(*).startWithIgnoreCase(null)              => FAIL
-     * Verifier.verify(*).startWithIgnoreCase("")                => PASS
-     * Verifier.verify("abc def").startWithIgnoreCase("abc")     => PASS
-     * Verifier.verify("abc def").startWithIgnoreCase("def")     => FAIL
-     * Verifier.verify("abc def").startWithIgnoreCase("abc def") => PASS
-     * Verifier.verify("abc def").startWithIgnoreCase("ABC")     => PASS
+     * Verifier.verify((String) null).startWithIgnoreCase(*)     =&gt; FAIL
+     * Verifier.verify(*).startWithIgnoreCase(null)              =&gt; FAIL
+     * Verifier.verify(*).startWithIgnoreCase("")                =&gt; PASS
+     * Verifier.verify("abc def").startWithIgnoreCase("abc")     =&gt; PASS
+     * Verifier.verify("abc def").startWithIgnoreCase("def")     =&gt; FAIL
+     * Verifier.verify("abc def").startWithIgnoreCase("abc def") =&gt; PASS
+     * Verifier.verify("abc def").startWithIgnoreCase("ABC")     =&gt; PASS
      * </pre>
      *
      * @param other
@@ -1128,12 +1128,12 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
      * Verifies that the value contains only upper case letters.
      * </p>
      * <pre>
-     * Verifier.verify((String) null).upperCase() => FAIL
-     * Verifier.verify("abc").upperCase()         => FAIL
-     * Verifier.verify("abcDEF").upperCase()      => FAIL
-     * Verifier.verify("ABC123").upperCase()      => FAIL
-     * Verifier.verify("ABC").upperCase()         => PASS
-     * Verifier.verify("A B C").upperCase()       => FAIL
+     * Verifier.verify((String) null).upperCase() =&gt; FAIL
+     * Verifier.verify("abc").upperCase()         =&gt; FAIL
+     * Verifier.verify("abcDEF").upperCase()      =&gt; FAIL
+     * Verifier.verify("ABC123").upperCase()      =&gt; FAIL
+     * Verifier.verify("ABC").upperCase()         =&gt; PASS
+     * Verifier.verify("A B C").upperCase()       =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link StringVerifier} for chaining purposes.

--- a/src/main/java/io/skelp/verifier/type/ThrowableVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ThrowableVerifier.java
@@ -64,11 +64,11 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * Verifies that the value is a checked exception.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).checked()           => FAIL
-     * Verifier.verify(new Exception()).checked()            => PASS
-     * Verifier.verify(new IOException()).checked()          => PASS
-     * Verifier.verify(new RuntimeException()).checked()     => FAIL
-     * Verifier.verify(new NullPointerException()).checked() => FAIL
+     * Verifier.verify((Throwable) null).checked()           =&gt; FAIL
+     * Verifier.verify(new Exception()).checked()            =&gt; PASS
+     * Verifier.verify(new IOException()).checked()          =&gt; PASS
+     * Verifier.verify(new RuntimeException()).checked()     =&gt; FAIL
+     * Verifier.verify(new NullPointerException()).checked() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link ThrowableVerifier} for chaining purposes.
@@ -93,14 +93,14 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).causedBy(*)                                                         => FAIL
-     * Verifier.verify(*).causedBy((Class) null)                                                             => FAIL
-     * Verifier.verify(new IOException()).causedBy(NullPointerException.class)                               => FAIL
-     * Verifier.verify(new IOException()).causedBy(IOException.class)                                        => PASS
-     * Verifier.verify(new NullPointerException(new IOException())).causedBy(IllegalArgumentException.class) => FAIL
-     * Verifier.verify(new NullPointerException(new IOException())).causedBy(RuntimeException.class)         => PASS
-     * Verifier.verify(new NullPointerException(new IOException())).causedBy(IOException.class)              => PASS
-     * Verifier.verify(*).causedBy(Throwable.class)                                                          => PASS
+     * Verifier.verify((Throwable) null).causedBy(*)                                                         =&gt; FAIL
+     * Verifier.verify(*).causedBy((Class) null)                                                             =&gt; FAIL
+     * Verifier.verify(new IOException()).causedBy(NullPointerException.class)                               =&gt; FAIL
+     * Verifier.verify(new IOException()).causedBy(IOException.class)                                        =&gt; PASS
+     * Verifier.verify(new NullPointerException(new IOException())).causedBy(IllegalArgumentException.class) =&gt; FAIL
+     * Verifier.verify(new NullPointerException(new IOException())).causedBy(RuntimeException.class)         =&gt; PASS
+     * Verifier.verify(new NullPointerException(new IOException())).causedBy(IOException.class)              =&gt; PASS
+     * Verifier.verify(*).causedBy(Throwable.class)                                                          =&gt; PASS
      * </pre>
      *
      * @param type
@@ -134,11 +134,11 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).causedBy(*)                                  => FAIL
-     * Verifier.verify(*).causedBy((Throwable) null)                                  => FAIL
-     * Verifier.verify(ex = new IOException()).causedBy(new IOException())            => FAIL
-     * Verifier.verify(ex = new IOException()).causedBy(ex)                           => PASS
-     * Verifier.verify(new NullPointerException(ex = new IOException())).causedBy(ex) => PASS
+     * Verifier.verify((Throwable) null).causedBy(*)                                  =&gt; FAIL
+     * Verifier.verify(*).causedBy((Throwable) null)                                  =&gt; FAIL
+     * Verifier.verify(ex = new IOException()).causedBy(new IOException())            =&gt; FAIL
+     * Verifier.verify(ex = new IOException()).causedBy(ex)                           =&gt; PASS
+     * Verifier.verify(new NullPointerException(ex = new IOException())).causedBy(ex) =&gt; PASS
      * </pre>
      *
      * @param cause
@@ -167,11 +167,11 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).causedBy(*, *)                                  => FAIL
-     * Verifier.verify(*).causedBy(null, *)                                              => FAIL
-     * Verifier.verify(ex = new IOException()).causedBy(new IOException(), *)            => FAIL
-     * Verifier.verify(ex = new IOException()).causedBy(ex, *)                           => PASS
-     * Verifier.verify(new NullPointerException(ex = new IOException())).causedBy(ex, *) => PASS
+     * Verifier.verify((Throwable) null).causedBy(*, *)                                  =&gt; FAIL
+     * Verifier.verify(*).causedBy(null, *)                                              =&gt; FAIL
+     * Verifier.verify(ex = new IOException()).causedBy(new IOException(), *)            =&gt; FAIL
+     * Verifier.verify(ex = new IOException()).causedBy(ex, *)                           =&gt; PASS
+     * Verifier.verify(new NullPointerException(ex = new IOException())).causedBy(ex, *) =&gt; PASS
      * </pre>
      *
      * @param cause
@@ -201,13 +201,13 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).message(*)                                  => FAIL
-     * Verifier.verify(new Exception()).message(null)                                => PASS
-     * Verifier.verify(new Exception()).message("abc")                               => FAIL
-     * Verifier.verify(new Exception("abc")).message(null)                           => FAIL
-     * Verifier.verify(new Exception("abc")).message("def")                          => FAIL
-     * Verifier.verify(new Exception("abc")).message("abc")                          => PASS
-     * Verifier.verify(new Exception("abc")).message("ABC")                          => FAIL
+     * Verifier.verify((Throwable) null).message(*)                                  =&gt; FAIL
+     * Verifier.verify(new Exception()).message(null)                                =&gt; PASS
+     * Verifier.verify(new Exception()).message("abc")                               =&gt; FAIL
+     * Verifier.verify(new Exception("abc")).message(null)                           =&gt; FAIL
+     * Verifier.verify(new Exception("abc")).message("def")                          =&gt; FAIL
+     * Verifier.verify(new Exception("abc")).message("abc")                          =&gt; PASS
+     * Verifier.verify(new Exception("abc")).message("ABC")                          =&gt; FAIL
      * </pre>
      *
      * @param message
@@ -230,11 +230,11 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
      * Verifies that the value is a unchecked exception.
      * </p>
      * <pre>
-     * Verifier.verify((Throwable) null).unchecked()           => FAIL
-     * Verifier.verify(new Exception()).unchecked()            => FAIL
-     * Verifier.verify(new IOException()).unchecked()          => FAIL
-     * Verifier.verify(new RuntimeException()).unchecked()     => PASS
-     * Verifier.verify(new NullPointerException()).unchecked() => PASS
+     * Verifier.verify((Throwable) null).unchecked()           =&gt; FAIL
+     * Verifier.verify(new Exception()).unchecked()            =&gt; FAIL
+     * Verifier.verify(new IOException()).unchecked()          =&gt; FAIL
+     * Verifier.verify(new RuntimeException()).unchecked()     =&gt; PASS
+     * Verifier.verify(new NullPointerException()).unchecked() =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link ThrowableVerifier} for chaining purposes.

--- a/src/main/java/io/skelp/verifier/type/base/BaseCollectionVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseCollectionVerifier.java
@@ -67,12 +67,12 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Object[]) null).contain(*)                 => FAIL
-     * Verifier.verify(new Object[0]).contain(*)                   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).contain(147)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).contain(789)   => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).contain(null)  => FAIL
-     * Verifier.verify(new Object[]{123, 456, null}).contain(null) => PASS
+     * Verifier.verify((Object[]) null).contain(*)                 =&gt; FAIL
+     * Verifier.verify(new Object[0]).contain(*)                   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).contain(147)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).contain(789)   =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).contain(null)  =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, null}).contain(null) =&gt; PASS
      * </pre>
      *
      * @param element
@@ -98,14 +98,14 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Object[]) null).containAll(*)                      => FAIL
-     * Verifier.verify(new Object[0]).containAll(*)                        => FAIL
-     * Verifier.verify(new Object[]{*}).containAll((Object[]) null)        => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).containAll(147, 258)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).containAll(123, 147)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).containAll(789, 456)   => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).containAll(789, null)  => FAIL
-     * Verifier.verify(new Object[]{123, 456, null}).containAll(123, null) => PASS
+     * Verifier.verify((Object[]) null).containAll(*)                      =&gt; FAIL
+     * Verifier.verify(new Object[0]).containAll(*)                        =&gt; FAIL
+     * Verifier.verify(new Object[]{*}).containAll((Object[]) null)        =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).containAll(147, 258)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).containAll(123, 147)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).containAll(789, 456)   =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).containAll(789, null)  =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, null}).containAll(123, null) =&gt; PASS
      * </pre>
      *
      * @param elements
@@ -136,14 +136,14 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Object[]) null).containAny(*)                      => FAIL
-     * Verifier.verify(new Object[0]).containAny(*)                        => FAIL
-     * Verifier.verify(new Object[]{*}).containAny((Object[]) null)        => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).containAny(147, 258)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).containAny(123, 147)   => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).containAny(789, 456)   => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).containAny(789, null)  => PASS
-     * Verifier.verify(new Object[]{123, 456, null}).containAny(147, null) => PASS
+     * Verifier.verify((Object[]) null).containAny(*)                      =&gt; FAIL
+     * Verifier.verify(new Object[0]).containAny(*)                        =&gt; FAIL
+     * Verifier.verify(new Object[]{*}).containAny((Object[]) null)        =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).containAny(147, 258)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).containAny(123, 147)   =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).containAny(789, 456)   =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).containAny(789, null)  =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, null}).containAny(147, null) =&gt; PASS
      * </pre>
      *
      * @param elements
@@ -174,9 +174,9 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Object[]) null).empty()             => PASS
-     * Verifier.verify(new Object[0]).empty()               => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).empty() => FAIL
+     * Verifier.verify((Object[]) null).empty()             =&gt; PASS
+     * Verifier.verify(new Object[0]).empty()               =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).empty() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link BaseCollectionVerifier} for chaining purposes.
@@ -200,12 +200,12 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify((Object[]) null).sizeOf(1)             => FAIL
-     * Verifier.verify((Object[]) null).sizeOf(0)             => PASS
-     * Verifier.verify(new Object[0]).sizeOf(1)               => FAIL
-     * Verifier.verify(new Object[0]).sizeOf(0)               => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).sizeOf(0) => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).sizeOf(3) => PASS
+     * Verifier.verify((Object[]) null).sizeOf(1)             =&gt; FAIL
+     * Verifier.verify((Object[]) null).sizeOf(0)             =&gt; PASS
+     * Verifier.verify(new Object[0]).sizeOf(1)               =&gt; FAIL
+     * Verifier.verify(new Object[0]).sizeOf(0)               =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).sizeOf(0) =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).sizeOf(3) =&gt; PASS
      * </pre>
      *
      * @param size
@@ -232,13 +232,13 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@code assertion} instead of the value itself.
      * </p>
      * <pre>
-     * Verifier.verify(*).thatAll(null)                                           => FAIL
-     * Verifier.verify(*).not().thatAll(null)                                     => FAIL
-     * Verifier.verify((Object[]) null).thatAll(value -> true)                    => FAIL
-     * Verifier.verify(new Object[0]).thatAll(value -> false)                     => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -> value < 0)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -> value > 200) => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -> value > 100) => PASS
+     * Verifier.verify(*).thatAll(null)                                                 =&gt; FAIL
+     * Verifier.verify(*).not().thatAll(null)                                           =&gt; FAIL
+     * Verifier.verify((Object[]) null).thatAll(value -&gt; true)                       =&gt; FAIL
+     * Verifier.verify(new Object[0]).thatAll(value -&gt; false)                        =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -&gt; value &lt; 0)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -&gt; value &gt; 200) =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAll(value -&gt; value &gt; 100) =&gt; PASS
      * </pre>
      *
      * @param assertion
@@ -302,13 +302,13 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * {@code assertion} instead of the value itself.
      * </p>
      * <pre>
-     * Verifier.verify(*).thatAny(null)                                           => FAIL
-     * Verifier.verify(*).not().thatAny(null)                                     => FAIL
-     * Verifier.verify((Object[]) null).thatAny(value -> true)                    => FAIL
-     * Verifier.verify(new Object[0]).thatAny(value -> true)                      => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -> value < 0)   => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -> value > 200) => PASS
-     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -> value > 100) => PASS
+     * Verifier.verify(*).thatAny(null)                                                 =&gt; FAIL
+     * Verifier.verify(*).not().thatAny(null)                                           =&gt; FAIL
+     * Verifier.verify((Object[]) null).thatAny(value -&gt; true)                       =&gt; FAIL
+     * Verifier.verify(new Object[0]).thatAny(value -&gt; true)                         =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -&gt; value &lt; 0)   =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -&gt; value &gt; 200) =&gt; PASS
+     * Verifier.verify(new Object[]{123, 456, 789}).thatAny(value -&gt; value &gt; 100) =&gt; PASS
      * </pre>
      *
      * @param assertion

--- a/src/main/java/io/skelp/verifier/type/base/BaseComparableVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseComparableVerifier.java
@@ -60,14 +60,14 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).between(*, null)            => FAIL
-     * Verifier.verify(*).between(null, *)            => FAIL
-     * Verifier.verify((Integer) null).between(*, *)  => FAIL
-     * Verifier.verify(50).between(0, 25)             => FAIL
-     * Verifier.verify(50).between(75, 100)           => FAIL
-     * Verifier.verify(50).between(0, 100)            => PASS
-     * Verifier.verify(50).between(0, 50)             => PASS
-     * Verifier.verify(50).between(50, 100)           => PASS
+     * Verifier.verify(*).between(*, null)            =&gt; FAIL
+     * Verifier.verify(*).between(null, *)            =&gt; FAIL
+     * Verifier.verify((Integer) null).between(*, *)  =&gt; FAIL
+     * Verifier.verify(50).between(0, 25)             =&gt; FAIL
+     * Verifier.verify(50).between(75, 100)           =&gt; FAIL
+     * Verifier.verify(50).between(0, 100)            =&gt; PASS
+     * Verifier.verify(50).between(0, 50)             =&gt; PASS
+     * Verifier.verify(50).between(50, 100)           =&gt; PASS
      * </pre>
      *
      * @param start
@@ -98,14 +98,14 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).between(*, null, *, *)            => FAIL
-     * Verifier.verify(*).between(null, *, *, *)            => FAIL
-     * Verifier.verify((Integer) null).between(*, *, *, *)  => FAIL
-     * Verifier.verify(50).between(0, 25, *, *)             => FAIL
-     * Verifier.verify(50).between(75, 100, *, *)           => FAIL
-     * Verifier.verify(50).between(0, 100, *, *)            => PASS
-     * Verifier.verify(50).between(0, 50, *, *)             => PASS
-     * Verifier.verify(50).between(50, 100, *, *)           => PASS
+     * Verifier.verify(*).between(*, null, *, *)            =&gt; FAIL
+     * Verifier.verify(*).between(null, *, *, *)            =&gt; FAIL
+     * Verifier.verify((Integer) null).between(*, *, *, *)  =&gt; FAIL
+     * Verifier.verify(50).between(0, 25, *, *)             =&gt; FAIL
+     * Verifier.verify(50).between(75, 100, *, *)           =&gt; FAIL
+     * Verifier.verify(50).between(0, 100, *, *)            =&gt; PASS
+     * Verifier.verify(50).between(0, 50, *, *)             =&gt; PASS
+     * Verifier.verify(50).between(50, 100, *, *)           =&gt; PASS
      * </pre>
      *
      * @param start
@@ -133,14 +133,14 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).betweenExclusive(*, null)            => FAIL
-     * Verifier.verify(*).betweenExclusive(null, *)            => FAIL
-     * Verifier.verify((Integer) null).betweenExclusive(*, *)  => FAIL
-     * Verifier.verify(50).betweenExclusive(0, 25)             => FAIL
-     * Verifier.verify(50).betweenExclusive(75, 100)           => FAIL
-     * Verifier.verify(50).betweenExclusive(0, 100)            => PASS
-     * Verifier.verify(50).betweenExclusive(0, 50)             => FAIL
-     * Verifier.verify(50).betweenExclusive(50, 100)           => FAIL
+     * Verifier.verify(*).betweenExclusive(*, null)            =&gt; FAIL
+     * Verifier.verify(*).betweenExclusive(null, *)            =&gt; FAIL
+     * Verifier.verify((Integer) null).betweenExclusive(*, *)  =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(0, 25)             =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(75, 100)           =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(0, 100)            =&gt; PASS
+     * Verifier.verify(50).betweenExclusive(0, 50)             =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(50, 100)           =&gt; FAIL
      * </pre>
      *
      * @param start
@@ -171,14 +171,14 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).betweenExclusive(*, null, *, *)            => FAIL
-     * Verifier.verify(*).betweenExclusive(null, *, *, *)            => FAIL
-     * Verifier.verify((Integer) null).betweenExclusive(*, *, *, *)  => FAIL
-     * Verifier.verify(50).betweenExclusive(0, 25, *, *)             => FAIL
-     * Verifier.verify(50).betweenExclusive(75, 100, *, *)           => FAIL
-     * Verifier.verify(50).betweenExclusive(0, 100, *, *)            => PASS
-     * Verifier.verify(50).betweenExclusive(0, 50, *, *)             => FAIL
-     * Verifier.verify(50).betweenExclusive(50, 100, *, *)           => FAIL
+     * Verifier.verify(*).betweenExclusive(*, null, *, *)            =&gt; FAIL
+     * Verifier.verify(*).betweenExclusive(null, *, *, *)            =&gt; FAIL
+     * Verifier.verify((Integer) null).betweenExclusive(*, *, *, *)  =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(0, 25, *, *)             =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(75, 100, *, *)           =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(0, 100, *, *)            =&gt; PASS
+     * Verifier.verify(50).betweenExclusive(0, 50, *, *)             =&gt; FAIL
+     * Verifier.verify(50).betweenExclusive(50, 100, *, *)           =&gt; FAIL
      * </pre>
      *
      * @param start
@@ -206,12 +206,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).greaterThan(null)              => FAIL
-     * Verifier.verify((Integer) null).greaterThan(*)    => FAIL
-     * Verifier.verify((Integer) null).greaterThan(null) => FAIL
-     * Verifier.verify(123).greaterThan(123)             => FAIL
-     * Verifier.verify(123).greaterThan(987)             => FAIL
-     * Verifier.verify(123).greaterThan(62)              => PASS
+     * Verifier.verify(*).greaterThan(null)              =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThan(*)    =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThan(null) =&gt; FAIL
+     * Verifier.verify(123).greaterThan(123)             =&gt; FAIL
+     * Verifier.verify(123).greaterThan(987)             =&gt; FAIL
+     * Verifier.verify(123).greaterThan(62)              =&gt; PASS
      * </pre>
      *
      * @param other
@@ -240,12 +240,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).greaterThan(null, *)              => FAIL
-     * Verifier.verify((Integer) null).greaterThan(*, *)    => FAIL
-     * Verifier.verify((Integer) null).greaterThan(null, *) => FAIL
-     * Verifier.verify(123).greaterThan(123, *)             => FAIL
-     * Verifier.verify(123).greaterThan(987, *)             => FAIL
-     * Verifier.verify(123).greaterThan(62, *)              => PASS
+     * Verifier.verify(*).greaterThan(null, *)              =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThan(*, *)    =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThan(null, *) =&gt; FAIL
+     * Verifier.verify(123).greaterThan(123, *)             =&gt; FAIL
+     * Verifier.verify(123).greaterThan(987, *)             =&gt; FAIL
+     * Verifier.verify(123).greaterThan(62, *)              =&gt; PASS
      * </pre>
      *
      * @param other
@@ -269,12 +269,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).greaterThanOrEqualTo(null)              => FAIL
-     * Verifier.verify((Integer) null).greaterThanOrEqualTo(*)    => FAIL
-     * Verifier.verify((Integer) null).greaterThanOrEqualTo(null) => PASS
-     * Verifier.verify(123).greaterThanOrEqualTo(123)             => PASS
-     * Verifier.verify(123).greaterThanOrEqualTo(987)             => FAIL
-     * Verifier.verify(123).greaterThanOrEqualTo(62)              => PASS
+     * Verifier.verify(*).greaterThanOrEqualTo(null)              =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThanOrEqualTo(*)    =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThanOrEqualTo(null) =&gt; PASS
+     * Verifier.verify(123).greaterThanOrEqualTo(123)             =&gt; PASS
+     * Verifier.verify(123).greaterThanOrEqualTo(987)             =&gt; FAIL
+     * Verifier.verify(123).greaterThanOrEqualTo(62)              =&gt; PASS
      * </pre>
      *
      * @param other
@@ -303,12 +303,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).greaterThanOrEqualTo(null, *)              => FAIL
-     * Verifier.verify((Integer) null).greaterThanOrEqualTo(*, *)    => FAIL
-     * Verifier.verify((Integer) null).greaterThanOrEqualTo(null, *) => PASS
-     * Verifier.verify(123).greaterThanOrEqualTo(123, *)             => PASS
-     * Verifier.verify(123).greaterThanOrEqualTo(987, *)             => FAIL
-     * Verifier.verify(123).greaterThanOrEqualTo(62, *)              => PASS
+     * Verifier.verify(*).greaterThanOrEqualTo(null, *)              =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThanOrEqualTo(*, *)    =&gt; FAIL
+     * Verifier.verify((Integer) null).greaterThanOrEqualTo(null, *) =&gt; PASS
+     * Verifier.verify(123).greaterThanOrEqualTo(123, *)             =&gt; PASS
+     * Verifier.verify(123).greaterThanOrEqualTo(987, *)             =&gt; FAIL
+     * Verifier.verify(123).greaterThanOrEqualTo(62, *)              =&gt; PASS
      * </pre>
      *
      * @param other
@@ -332,12 +332,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).lessThan(null)              => FAIL
-     * Verifier.verify((Integer) null).lessThan(*)    => FAIL
-     * Verifier.verify((Integer) null).lessThan(null) => FAIL
-     * Verifier.verify(123).lessThan(123)             => FAIL
-     * Verifier.verify(123).lessThan(987)             => PASS
-     * Verifier.verify(123).lessThan(62)              => FAIL
+     * Verifier.verify(*).lessThan(null)              =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThan(*)    =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThan(null) =&gt; FAIL
+     * Verifier.verify(123).lessThan(123)             =&gt; FAIL
+     * Verifier.verify(123).lessThan(987)             =&gt; PASS
+     * Verifier.verify(123).lessThan(62)              =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -365,12 +365,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).lessThan(null, *)              => FAIL
-     * Verifier.verify((Integer) null).lessThan(*, *)    => FAIL
-     * Verifier.verify((Integer) null).lessThan(null, *) => FAIL
-     * Verifier.verify(123).lessThan(123, *)             => FAIL
-     * Verifier.verify(123).lessThan(987, *)             => PASS
-     * Verifier.verify(123).lessThan(62, *)              => FAIL
+     * Verifier.verify(*).lessThan(null, *)              =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThan(*, *)    =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThan(null, *) =&gt; FAIL
+     * Verifier.verify(123).lessThan(123, *)             =&gt; FAIL
+     * Verifier.verify(123).lessThan(987, *)             =&gt; PASS
+     * Verifier.verify(123).lessThan(62, *)              =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -394,12 +394,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).lessThanOrEqualTo(null)              => FAIL
-     * Verifier.verify((Integer) null).lessThanOrEqualTo(*)    => FAIL
-     * Verifier.verify((Integer) null).lessThanOrEqualTo(null) => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(123)             => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(987)             => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(62)              => FAIL
+     * Verifier.verify(*).lessThanOrEqualTo(null)              =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThanOrEqualTo(*)    =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThanOrEqualTo(null) =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(123)             =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(987)             =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(62)              =&gt; FAIL
      * </pre>
      *
      * @param other
@@ -428,12 +428,12 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).lessThanOrEqualTo(null, *)              => FAIL
-     * Verifier.verify((Integer) null).lessThanOrEqualTo(*, *)    => FAIL
-     * Verifier.verify((Integer) null).lessThanOrEqualTo(null, *) => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(123, *)             => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(987, *)             => PASS
-     * Verifier.verify(123).lessThanOrEqualTo(62, *)              => FAIL
+     * Verifier.verify(*).lessThanOrEqualTo(null, *)              =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThanOrEqualTo(*, *)    =&gt; FAIL
+     * Verifier.verify((Integer) null).lessThanOrEqualTo(null, *) =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(123, *)             =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(987, *)             =&gt; PASS
+     * Verifier.verify(123).lessThanOrEqualTo(62, *)              =&gt; FAIL
      * </pre>
      *
      * @param other

--- a/src/main/java/io/skelp/verifier/type/base/BaseNumberVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseNumberVerifier.java
@@ -107,11 +107,11 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is even (i.e. divisible by two without a remainder).
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).even() => FAIL
-     * Verifier.verify(0).even()              => PASS
-     * Verifier.verify(1).even()              => FAIL
-     * Verifier.verify(2).even()              => PASS
-     * Verifier.verify(12).even()             => PASS
+     * Verifier.verify((Integer) null).even() =&gt; FAIL
+     * Verifier.verify(0).even()              =&gt; PASS
+     * Verifier.verify(1).even()              =&gt; FAIL
+     * Verifier.verify(2).even()              =&gt; PASS
+     * Verifier.verify(12).even()             =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.
@@ -126,10 +126,10 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is negative (i.e. less that zero).
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).negative() => FAIL
-     * Verifier.verify(0).negative()              => FAIL
-     * Verifier.verify(1).negative()              => FAIL
-     * Verifier.verify(-1).negative()             => PASS
+     * Verifier.verify((Integer) null).negative() =&gt; FAIL
+     * Verifier.verify(0).negative()              =&gt; FAIL
+     * Verifier.verify(1).negative()              =&gt; FAIL
+     * Verifier.verify(-1).negative()             =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.
@@ -144,11 +144,11 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is odd (i.e. has one left over as a remainder when divided by two).
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).odd() => FAIL
-     * Verifier.verify(0).odd()              => FAIL
-     * Verifier.verify(1).odd()              => PASS
-     * Verifier.verify(2).odd()              => FAIL
-     * Verifier.verify(13).odd()             => PASS
+     * Verifier.verify((Integer) null).odd() =&gt; FAIL
+     * Verifier.verify(0).odd()              =&gt; FAIL
+     * Verifier.verify(1).odd()              =&gt; PASS
+     * Verifier.verify(2).odd()              =&gt; FAIL
+     * Verifier.verify(13).odd()             =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.
@@ -163,11 +163,11 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is one.
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).one() => FAIL
-     * Verifier.verify(0).one()              => FAIL
-     * Verifier.verify(1).one()              => PASS
-     * Verifier.verify(-1).one()             => FAIL
-     * Verifier.verify(2).one()              => FAIL
+     * Verifier.verify((Integer) null).one() =&gt; FAIL
+     * Verifier.verify(0).one()              =&gt; FAIL
+     * Verifier.verify(1).one()              =&gt; PASS
+     * Verifier.verify(-1).one()             =&gt; FAIL
+     * Verifier.verify(2).one()              =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.
@@ -182,10 +182,10 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is positive (i.e. greater than or equal to zero).
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).positive() => FAIL
-     * Verifier.verify(0).positive()              => PASS
-     * Verifier.verify(1).positive()              => PASS
-     * Verifier.verify(-1).positive()             => FAIL
+     * Verifier.verify((Integer) null).positive() =&gt; FAIL
+     * Verifier.verify(0).positive()              =&gt; PASS
+     * Verifier.verify(1).positive()              =&gt; PASS
+     * Verifier.verify(-1).positive()             =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.
@@ -200,10 +200,10 @@ public interface BaseNumberVerifier<T extends Number, V extends BaseNumberVerifi
      * Verifies that the value is zero.
      * </p>
      * <pre>
-     * Verifier.verify((Integer) null).zero() => FAIL
-     * Verifier.verify(0).zero()              => PASS
-     * Verifier.verify(1).zero()              => FAIL
-     * Verifier.verify(-1).zero()             => FAIL
+     * Verifier.verify((Integer) null).zero() =&gt; FAIL
+     * Verifier.verify(0).zero()              =&gt; PASS
+     * Verifier.verify(1).zero()              =&gt; FAIL
+     * Verifier.verify(-1).zero()             =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link BaseNumberVerifier} for chaining purposes.

--- a/src/main/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifier.java
@@ -65,13 +65,13 @@ public abstract class BaseSortableCollectionVerifier<E, T, V extends BaseSortabl
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sortedBy(null)                                                   => FAIL
-     * Verifier.verify(*).not().sortedBy(null)                                             => FAIL
-     * Verifier.verify((Object[]) null).sortedBy(*)                                        => FAIL
-     * Verifier.verify(new Object[0]).sortedBy(*)                                          => PASS
-     * Verifier.verify(new Object[]{123}).sortedBy(*)                                      => PASS
-     * Verifier.verify(new Object[]{987, 654, 321}).sortedBy((o1, o2) -> o1.compareTo(o2)) => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).sortedBy((o1, o2) -> o1.compareTo(o2)) => PASS
+     * Verifier.verify(*).sortedBy(null)                                                      =&gt; FAIL
+     * Verifier.verify(*).not().sortedBy(null)                                                =&gt; FAIL
+     * Verifier.verify((Object[]) null).sortedBy(*)                                           =&gt; FAIL
+     * Verifier.verify(new Object[0]).sortedBy(*)                                             =&gt; PASS
+     * Verifier.verify(new Object[]{123}).sortedBy(*)                                         =&gt; PASS
+     * Verifier.verify(new Object[]{987, 654, 321}).sortedBy((o1, o2) -&gt; o1.compareTo(o2)) =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).sortedBy((o1, o2) -&gt; o1.compareTo(o2)) =&gt; PASS
      * </pre>
      *
      * @param comparator
@@ -100,13 +100,13 @@ public abstract class BaseSortableCollectionVerifier<E, T, V extends BaseSortabl
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sortedBy(null, *)                                                   => FAIL
-     * Verifier.verify(*).not().sortedBy(null, *)                                             => FAIL
-     * Verifier.verify((Object[]) null).sortedBy(*, *)                                        => FAIL
-     * Verifier.verify(new Object[0]).sortedBy(*, *)                                          => PASS
-     * Verifier.verify(new Object[]{123}).sortedBy(*, *)                                      => PASS
-     * Verifier.verify(new Object[]{987, 654, 321}).sortedBy((o1, o2) -> o1.compareTo(o2), *) => FAIL
-     * Verifier.verify(new Object[]{123, 456, 789}).sortedBy((o1, o2) -> o1.compareTo(o2), *) => PASS
+     * Verifier.verify(*).sortedBy(null, *)                                                      =&gt; FAIL
+     * Verifier.verify(*).not().sortedBy(null, *)                                                =&gt; FAIL
+     * Verifier.verify((Object[]) null).sortedBy(*, *)                                           =&gt; FAIL
+     * Verifier.verify(new Object[0]).sortedBy(*, *)                                             =&gt; PASS
+     * Verifier.verify(new Object[]{123}).sortedBy(*, *)                                         =&gt; PASS
+     * Verifier.verify(new Object[]{987, 654, 321}).sortedBy((o1, o2) -&gt; o1.compareTo(o2), *) =&gt; FAIL
+     * Verifier.verify(new Object[]{123, 456, 789}).sortedBy((o1, o2) -&gt; o1.compareTo(o2), *) =&gt; PASS
      * </pre>
      *
      * @param comparator

--- a/src/main/java/io/skelp/verifier/type/base/BaseTimeVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseTimeVerifier.java
@@ -61,11 +61,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameDayAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameDayAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("31 Aug 2016 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("15 Oct 2016 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("31 Oct 2016 00:07:02")) => PASS
+     * Verifier.verify(*).sameDayAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameDayAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("31 Aug 2016 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("15 Oct 2016 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameDayAs(parse("31 Oct 2016 00:07:02")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -95,10 +95,10 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameEraAs(null)                                                            => FAIL
-     * Verifier.verify((Date) null).sameEraAs(*)                                                     => FAIL
-     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameEraAs(parse("31 Oct 2016 BC 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameEraAs(parse("15 Aug 2017 AD 00:07:02")) => PASS
+     * Verifier.verify(*).sameEraAs(null)                                                            =&gt; FAIL
+     * Verifier.verify((Date) null).sameEraAs(*)                                                     =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameEraAs(parse("31 Oct 2016 BC 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameEraAs(parse("15 Aug 2017 AD 00:07:02")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -126,11 +126,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameHourAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameHourAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("15 Oct 2016 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("31 Oct 2016 00:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("31 Oct 2016 13:15:02")) => PASS
+     * Verifier.verify(*).sameHourAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameHourAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("15 Oct 2016 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("31 Oct 2016 00:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameHourAs(parse("31 Oct 2016 13:15:02")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -161,11 +161,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameMinuteAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameMinuteAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 00:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 13:15:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 13:45:02")) => PASS
+     * Verifier.verify(*).sameMinuteAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameMinuteAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 00:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 13:15:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMinuteAs(parse("31 Oct 2016 13:45:02")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -197,11 +197,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameMonthAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameMonthAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("31 Oct 2017 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("31 Aug 2016 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("15 Oct 2016 00:07:02")) => PASS
+     * Verifier.verify(*).sameMonthAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameMonthAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("31 Oct 2017 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("31 Aug 2016 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameMonthAs(parse("15 Oct 2016 00:07:02")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -231,11 +231,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameSecondAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameSecondAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:15:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:45:02")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:45:30")) => PASS
+     * Verifier.verify(*).sameSecondAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameSecondAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:15:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:45:02")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameSecondAs(parse("31 Oct 2016 13:45:30")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -268,11 +268,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameTimeAs(null)                                                              => FAIL
-     * Verifier.verify((Date) null).sameTimeAs(*)                                                       => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:15.123")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:30.789")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:30.123")) => PASS
+     * Verifier.verify(*).sameTimeAs(null)                                                              =&gt; FAIL
+     * Verifier.verify((Date) null).sameTimeAs(*)                                                       =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:15.123")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:30.789")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30.123")).sameTimeAs(parse("31 Oct 2016 13:45:30.123")) =&gt; PASS
      * </pre>
      *
      * @param other
@@ -300,11 +300,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameWeekAs(null)                                                      => FAIL
-     * Verifier.verify((Date) null).sameWeekAs(*)                                               => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("31 Oct 2017 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("15 Oct 2016 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("1 Nov 2016 00:07:02"))  => PASS
+     * Verifier.verify(*).sameWeekAs(null)                                                      =&gt; FAIL
+     * Verifier.verify((Date) null).sameWeekAs(*)                                               =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("31 Oct 2017 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("15 Oct 2016 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 13:45:30")).sameWeekAs(parse("1 Nov 2016 00:07:02"))  =&gt; PASS
      * </pre>
      *
      * @param other
@@ -334,11 +334,11 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
      * {@literal null} references are handled gracefully without exceptions.
      * </p>
      * <pre>
-     * Verifier.verify(*).sameYearAs(null)                                                            => FAIL
-     * Verifier.verify((Date) null).sameYearAs(*)                                                     => FAIL
-     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("31 Oct 2016 BC 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("31 Oct 2017 AD 13:45:30")) => FAIL
-     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("15 Aug 2016 AD 00:07:02")) => PASS
+     * Verifier.verify(*).sameYearAs(null)                                                            =&gt; FAIL
+     * Verifier.verify((Date) null).sameYearAs(*)                                                     =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("31 Oct 2016 BC 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("31 Oct 2017 AD 13:45:30")) =&gt; FAIL
+     * Verifier.verify(parse("31 Oct 2016 AD 13:45:30")).sameYearAs(parse("15 Aug 2016 AD 00:07:02")) =&gt; PASS
      * </pre>
      *
      * @param other

--- a/src/main/java/io/skelp/verifier/type/base/BaseTruthVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseTruthVerifier.java
@@ -74,9 +74,9 @@ public interface BaseTruthVerifier<T, V extends BaseTruthVerifier<T, V>> extends
      * {@literal null} value is <b>always</b> considered to be falsy.
      * </p>
      * <pre>
-     * Verifier.verify((Boolean) null).falsy() => PASS
-     * Verifier.verify(false).falsy()          => PASS
-     * Verifier.verify(true).falsy()           => FAIL
+     * Verifier.verify((Boolean) null).falsy() =&gt; PASS
+     * Verifier.verify(false).falsy()          =&gt; PASS
+     * Verifier.verify(true).falsy()           =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link BaseTruthVerifier} for chaining purposes.
@@ -96,9 +96,9 @@ public interface BaseTruthVerifier<T, V extends BaseTruthVerifier<T, V>> extends
      * {@literal null} value is <b>never</b> considered to be truthy.
      * </p>
      * <pre>
-     * Verifier.verify((Boolean) null).truthy() => FAIL
-     * Verifier.verify(false).truthy()          => FAIL
-     * Verifier.verify(true).truthy()           => PASS
+     * Verifier.verify((Boolean) null).truthy() =&gt; FAIL
+     * Verifier.verify(false).truthy()          =&gt; FAIL
+     * Verifier.verify(true).truthy()           =&gt; PASS
      * </pre>
      *
      * @return A reference to this {@link BaseTruthVerifier} for chaining purposes.


### PR DESCRIPTION
Now that the JavaDoc Maven plugin has been activated the build has been breaking due to JavaDoc issues. These are *all* related to using `<` and `>` symbols instead of `&lt;` and `&gt;` HTML entities respectively.

This PR corrects all problems and fixes the build.