### PR TITLE
Always notify Gitter of build result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/a4d2c0b15b94444b173e
-    on_success: change
+    on_success: always
     on_failure: always
     on_start: never


### PR DESCRIPTION
Initially, with #6 I had configured our CI to only notify Gitter when a build started to pass or any time it failed. Now it will always notify Gitter if it passes or fails.