### PR TITLE
Support multiple reporters (Take 2)

### DIFF
--- a/src/main/java/io/skelp/verifier/AbstractCustomVerifier.java
+++ b/src/main/java/io/skelp/verifier/AbstractCustomVerifier.java
@@ -192,7 +192,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = isEqualTo(value, other);
 
-        verification.check(result, MessageKeys.EQUAL_TO, name);
+        verification.report(result, MessageKeys.EQUAL_TO, name);
 
         return chain();
     }
@@ -202,7 +202,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = matchAny(others, input -> isEqualTo(value, input));
 
-        verification.check(result, MessageKeys.EQUAL_TO_ANY, (Object) others);
+        verification.report(result, MessageKeys.EQUAL_TO_ANY, (Object) others);
 
         return chain();
     }
@@ -212,7 +212,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = value != null && value.hashCode() == hashCode;
 
-        verification.check(result, MessageKeys.HASHED_AS, hashCode);
+        verification.report(result, MessageKeys.HASHED_AS, hashCode);
 
         return chain();
     }
@@ -221,7 +221,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
     public V instanceOf(final Class<?> cls) {
         final boolean result = cls != null && cls.isInstance(verification.getValue());
 
-        verification.check(result, MessageKeys.INSTANCE_OF, cls);
+        verification.report(result, MessageKeys.INSTANCE_OF, cls);
 
         return chain();
     }
@@ -231,7 +231,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = value != null && matchAll(classes, input -> input != null && input.isInstance(value));
 
-        verification.check(result, MessageKeys.INSTANCE_OF_ALL, (Object) classes);
+        verification.report(result, MessageKeys.INSTANCE_OF_ALL, (Object) classes);
 
         return chain();
     }
@@ -241,7 +241,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = value != null && matchAny(classes, input -> input != null && input.isInstance(value));
 
-        verification.check(result, MessageKeys.INSTANCE_OF_ANY, (Object) classes);
+        verification.report(result, MessageKeys.INSTANCE_OF_ANY, (Object) classes);
 
         return chain();
     }
@@ -276,7 +276,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
     public V nulled() {
         final boolean result = verification.getValue() == null;
 
-        verification.check(result, MessageKeys.NULLED);
+        verification.report(result, MessageKeys.NULLED);
 
         return chain();
     }
@@ -290,7 +290,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
     public V sameAs(final Object other, final Object name) {
         final boolean result = verification.getValue() == other;
 
-        verification.check(result, MessageKeys.SAME_AS, name);
+        verification.report(result, MessageKeys.SAME_AS, name);
 
         return chain();
     }
@@ -300,7 +300,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
         final T value = verification.getValue();
         final boolean result = matchAny(others, input -> value == input);
 
-        verification.check(result, MessageKeys.SAME_AS_ANY, (Object) others);
+        verification.report(result, MessageKeys.SAME_AS_ANY, (Object) others);
 
         return chain();
     }
@@ -317,7 +317,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
 
         final boolean result = assertion.verify(verification.getValue());
 
-        verification.check(result, key, args);
+        verification.report(result, key, args);
 
         return chain();
     }
@@ -329,7 +329,7 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
 
         final boolean result = assertion.verify(verification.getValue());
 
-        verification.check(result, message, args);
+        verification.report(result, message, args);
 
         return chain();
     }

--- a/src/main/java/io/skelp/verifier/CustomVerifierProvider.java
+++ b/src/main/java/io/skelp/verifier/CustomVerifierProvider.java
@@ -29,6 +29,16 @@ import io.skelp.verifier.verification.Verification;
  * Provides {@link CustomVerifier} instances to be used to verify custom data types based on their class and the current
  * {@link Verification}.
  * </p>
+ * <p>
+ * {@code CustomVerifierProviders} are registered via Java's SPI, so in order to register a custom
+ * {@code CustomVerifierProvider} projects should contain should create a
+ * {@code io.skelp.verifier.CustomVerifierProvider} file within {@code META-INF/services} listing the class reference
+ * for each custom {@code CustomVerifierProvider} (e.g. {@code com.example.verifier.MyCustomCustomVerifierProvider}) on
+ * separate lines. {@code CustomVerifierProviders} are also {@link Weighted}, which means that they are loaded in
+ * priority order (the lower the weight, the higher the priority). Verifier has a built-in default
+ * {@code CustomVerifierProvider} which is given a low priority (i.e. {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow
+ * custom implementations to be easily ordered around it.
+ * </p>
  *
  * @author Alasdair Mercer
  * @since 0.2.0

--- a/src/main/java/io/skelp/verifier/message/AbstractMessageSource.java
+++ b/src/main/java/io/skelp/verifier/message/AbstractMessageSource.java
@@ -290,7 +290,7 @@ public abstract class AbstractMessageSource implements MessageSource {
     }
 
     @Override
-    public String getMessage(final Verification<?> verification, final MessageKey key, final Object... args) {
+    public String getMessage(final Verification<?> verification, final MessageKey key, final Object[] args) {
         final String formattedMessage = getMessageInternal(key, args, verification);
         if (formattedMessage != null) {
             return buildMessage(formattedMessage, verification);
@@ -305,7 +305,7 @@ public abstract class AbstractMessageSource implements MessageSource {
     }
 
     @Override
-    public String getMessage(final Verification<?> verification, final String message, final Object... args) {
+    public String getMessage(final Verification<?> verification, final String message, final Object[] args) {
         final String formattedMessage = getMessageInternal(message, args, verification);
         if (formattedMessage != null) {
             return buildMessage(formattedMessage, verification);
@@ -317,7 +317,7 @@ public abstract class AbstractMessageSource implements MessageSource {
 
     /**
      * <p>
-     * Called internally by {@link #getMessage(Verification, MessageKey, Object...)} to handle the actual logic of
+     * Called internally by {@link #getMessage(Verification, MessageKey, Object[])} to handle the actual logic of
      * looking up a message based on the specified {@code key} and potentially formatting it using the optional format
      * {@code args} provided.
      * </p>
@@ -342,7 +342,7 @@ public abstract class AbstractMessageSource implements MessageSource {
      * @throws IllegalArgumentException
      *         If the resolved message is formatted but is an invalid format pattern or any of the format {@code args}
      *         are invalid for their placeholders.
-     * @see #getMessage(Verification, MessageKey, Object...)
+     * @see #getMessage(Verification, MessageKey, Object[])
      */
     protected String getMessageInternal(final MessageKey key, final Object[] args, final Verification<?> verification) {
         if (key == null) {
@@ -366,7 +366,7 @@ public abstract class AbstractMessageSource implements MessageSource {
 
     /**
      * <p>
-     * Called internally by {@link #getMessage(Verification, String, Object...)} to handle the actual logic of
+     * Called internally by {@link #getMessage(Verification, String, Object[])} to handle the actual logic of
      * potentially formatting {@code message} using the optional format {@code args} provided.
      * </p>
      * <p>
@@ -388,7 +388,7 @@ public abstract class AbstractMessageSource implements MessageSource {
      * @throws IllegalArgumentException
      *         If {@code message} is formatted but is an invalid format pattern or any of the format {@code args} are
      *         invalid for their placeholders.
-     * @see #getMessage(Verification, String, Object...)
+     * @see #getMessage(Verification, String, Object[])
      */
     protected String getMessageInternal(final String message, final Object[] args, final Verification<?> verification) {
         if (message == null) {

--- a/src/main/java/io/skelp/verifier/message/MessageSource.java
+++ b/src/main/java/io/skelp/verifier/message/MessageSource.java
@@ -76,7 +76,7 @@ public interface MessageSource {
      * @throws NoSuchMessageException
      *         If no message could be found for {@code key} or any other that is required to build the full message.
      */
-    String getMessage(Verification<?> verification, MessageKey key, Object... args);
+    String getMessage(Verification<?> verification, MessageKey key, Object[] args);
 
     /**
      * <p>
@@ -102,5 +102,5 @@ public interface MessageSource {
      * @throws NoSuchMessageException
      *         If no message could be found for any keys that are required to build the full message.
      */
-    String getMessage(Verification<?> verification, String message, Object... args);
+    String getMessage(Verification<?> verification, String message, Object[] args);
 }

--- a/src/main/java/io/skelp/verifier/message/MessageSourceProvider.java
+++ b/src/main/java/io/skelp/verifier/message/MessageSourceProvider.java
@@ -28,6 +28,16 @@ import io.skelp.verifier.service.Weighted;
  * <p>
  * Provides {@link MessageSource} instances to be used to retrieve localized and/or formatted messages.
  * </p>
+ * <p>
+ * {@code MessageSourceProviders} are registered via Java's SPI, so in order to register a custom
+ * {@code MessageSourceProvider} projects should contain should create a
+ * {@code io.skelp.verifier.verification.message.MessageSourceProvider} file within {@code META-INF/services} listing
+ * the class reference for each custom {@code MessageSourceProvider} (e.g.
+ * {@code com.example.verifier.MyCustomMessageSourceProvider}) on separate lines. {@code MessageSourceProviders} are
+ * also {@link Weighted}, which means that they are loaded in priority order (the lower the weight, the higher the
+ * priority). Verifier has a built-in default {@code MessageSourceProvider} which is given a low priority (i.e.
+ * {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow custom implementations to be easily ordered around it.
+ * </p>
  *
  * @author Alasdair Mercer
  * @since 0.2.0

--- a/src/main/java/io/skelp/verifier/message/formatter/Formatter.java
+++ b/src/main/java/io/skelp/verifier/message/formatter/Formatter.java
@@ -31,6 +31,12 @@ import io.skelp.verifier.verification.Verification;
  * {@code Formatters} can choose which types of objects that they support to allow other implementations to provide more
  * precise formatting for that type as only one {@code Formatter} will be used for a single instance.
  * </p>
+ * <p>
+ * {@code Formatters} are registered via Java's SPI, so in order to register a custom {@code Formatter} projects should
+ * contain should create a {@code io.skelp.verifier.message.formatter.Formatter} file within {@code META-INF/services}
+ * listing the class reference for each custom {@code Formatter} (e.g. {@code com.example.verifier.MyCustomFormatter})
+ * on separate lines.
+ * </p>
  *
  * @author Alasdair Mercer
  * @since 0.2.0

--- a/src/main/java/io/skelp/verifier/message/locale/DefaultLocaleContextProvider.java
+++ b/src/main/java/io/skelp/verifier/message/locale/DefaultLocaleContextProvider.java
@@ -33,7 +33,7 @@ import java.util.Locale;
  * @see Locale#getDefault()
  * @since 0.2.0
  */
-public class DefaultLocaleContextProvider implements LocaleContextProvider {
+public final class DefaultLocaleContextProvider implements LocaleContextProvider {
 
     @Override
     public LocaleContext getLocaleContext() {

--- a/src/main/java/io/skelp/verifier/message/locale/LocaleContextProvider.java
+++ b/src/main/java/io/skelp/verifier/message/locale/LocaleContextProvider.java
@@ -28,6 +28,16 @@ import io.skelp.verifier.service.Weighted;
  * <p>
  * Provides {@link LocaleContext} instances to be used to localize messages.
  * </p>
+ * <p>
+ * {@code LocaleContextProviders} are registered via Java's SPI, so in order to register a custom
+ * {@code LocaleContextProvider} projects should contain should create a
+ * {@code io.skelp.verifier.verification.message.locale.LocaleContextProvider} file within {@code META-INF/services}
+ * listing the class reference for each custom {@code LocaleContextProvider} (e.g.
+ * {@code com.example.verifier.MyCustomLocaleContextProvider}) on separate lines. {@code LocaleContextProviders} are
+ * also {@link Weighted}, which means that they are loaded in priority order (the lower the weight, the higher the
+ * priority). Verifier has a built-in default {@code LocaleContextProvider} which is given a low priority (i.e.
+ * {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow custom implementations to be easily ordered around it.
+ * </p>
  *
  * @author Alasdair Mercer
  * @since 0.2.0

--- a/src/main/java/io/skelp/verifier/message/locale/SimpleLocaleContext.java
+++ b/src/main/java/io/skelp/verifier/message/locale/SimpleLocaleContext.java
@@ -33,7 +33,7 @@ import java.util.Locale;
  * @see Locale#getDefault()
  * @since 0.2.0
  */
-public class SimpleLocaleContext implements LocaleContext {
+public final class SimpleLocaleContext implements LocaleContext {
 
     private final Locale locale;
 

--- a/src/main/java/io/skelp/verifier/type/BigDecimalVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/BigDecimalVerifier.java
@@ -60,7 +60,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && !value.stripTrailingZeros().unscaledValue().testBit(0);
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -70,7 +70,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value == null || value.compareTo(BigDecimal.ZERO) == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -80,7 +80,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigDecimal.ZERO) < 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -90,7 +90,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.stripTrailingZeros().unscaledValue().testBit(0);
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -100,7 +100,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigDecimal.ONE) == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -110,7 +110,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigDecimal.ZERO) >= 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -120,7 +120,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigDecimal.ONE) == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -130,7 +130,7 @@ public final class BigDecimalVerifier extends BaseComparableVerifier<BigDecimal,
         final BigDecimal value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigDecimal.ZERO) == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/BigIntegerVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/BigIntegerVerifier.java
@@ -60,7 +60,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && !value.testBit(0);
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -70,7 +70,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value == null || value.compareTo(BigInteger.ZERO) == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -80,7 +80,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigInteger.ZERO) < 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -90,7 +90,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.testBit(0);
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -100,7 +100,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigInteger.ONE) == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -110,7 +110,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigInteger.ZERO) >= 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -120,7 +120,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigInteger.ONE) == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -130,7 +130,7 @@ public final class BigIntegerVerifier extends BaseComparableVerifier<BigInteger,
         final BigInteger value = verification().getValue();
         final boolean result = value != null && value.compareTo(BigInteger.ZERO) == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/BooleanVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/BooleanVerifier.java
@@ -55,7 +55,7 @@ public final class BooleanVerifier extends BaseComparableVerifier<Boolean, Boole
     public BooleanVerifier falsy() {
         final boolean result = !Boolean.TRUE.equals(verification().getValue());
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -64,7 +64,7 @@ public final class BooleanVerifier extends BaseComparableVerifier<Boolean, Boole
     public BooleanVerifier truthy() {
         final boolean result = Boolean.TRUE.equals(verification().getValue());
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/ByteVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ByteVerifier.java
@@ -58,7 +58,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value % 2 == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value == null || value == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value < 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value % 2 != 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value >= 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class ByteVerifier extends BaseComparableVerifier<Byte, ByteVerifie
         final Byte value = verification().getValue();
         final boolean result = value != null && value == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/CharacterVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/CharacterVerifier.java
@@ -91,7 +91,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isLetter(value);
 
-        verification().check(result, MessageKeys.ALPHA);
+        verification().report(result, MessageKeys.ALPHA);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isLetterOrDigit(value);
 
-        verification().check(result, MessageKeys.ALPHANUMERIC);
+        verification().report(result, MessageKeys.ALPHANUMERIC);
 
         return this;
     }
@@ -144,7 +144,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && value < 128;
 
-        verification().check(result, MessageKeys.ASCII);
+        verification().report(result, MessageKeys.ASCII);
 
         return this;
     }
@@ -171,7 +171,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && isAsciiAlpha(value);
 
-        verification().check(result, MessageKeys.ASCII_ALPHA);
+        verification().report(result, MessageKeys.ASCII_ALPHA);
 
         return this;
     }
@@ -200,7 +200,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && isAsciiAlphaLowerCase(value);
 
-        verification().check(result, MessageKeys.ASCII_ALPHA_LOWER_CASE);
+        verification().report(result, MessageKeys.ASCII_ALPHA_LOWER_CASE);
 
         return this;
     }
@@ -229,7 +229,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && isAsciiAlphaUpperCase(value);
 
-        verification().check(result, MessageKeys.ASCII_ALPHA_UPPER_CASE);
+        verification().report(result, MessageKeys.ASCII_ALPHA_UPPER_CASE);
 
         return this;
     }
@@ -256,7 +256,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && (isAsciiAlpha(value) || isAsciiNumeric(value));
 
-        verification().check(result, MessageKeys.ASCII_ALPHANUMERIC);
+        verification().report(result, MessageKeys.ASCII_ALPHANUMERIC);
 
         return this;
     }
@@ -282,7 +282,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && (value < 32 || value == 127);
 
-        verification().check(result, MessageKeys.ASCII_CONTROL);
+        verification().report(result, MessageKeys.ASCII_CONTROL);
 
         return this;
     }
@@ -309,7 +309,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && isAsciiNumeric(value);
 
-        verification().check(result, MessageKeys.ASCII_NUMERIC);
+        verification().report(result, MessageKeys.ASCII_NUMERIC);
 
         return this;
     }
@@ -337,7 +337,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && value >= 32 && value < 127;
 
-        verification().check(result, MessageKeys.ASCII_PRINTABLE);
+        verification().report(result, MessageKeys.ASCII_PRINTABLE);
 
         return this;
     }
@@ -347,7 +347,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value == null || value == '0';
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -377,7 +377,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isLowerCase(value);
 
-        verification().check(result, MessageKeys.LOWER_CASE);
+        verification().report(result, MessageKeys.LOWER_CASE);
 
         return this;
     }
@@ -404,7 +404,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isDigit(value);
 
-        verification().check(result, MessageKeys.NUMERIC);
+        verification().report(result, MessageKeys.NUMERIC);
 
         return this;
     }
@@ -414,7 +414,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && value == '1';
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -444,7 +444,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isUpperCase(value);
 
-        verification().check(result, MessageKeys.UPPER_CASE);
+        verification().report(result, MessageKeys.UPPER_CASE);
 
         return this;
     }
@@ -472,7 +472,7 @@ public final class CharacterVerifier extends BaseComparableVerifier<Character, C
         final Character value = verification().getValue();
         final boolean result = value != null && Character.isWhitespace(value);
 
-        verification().check(result, MessageKeys.WHITESPACE);
+        verification().report(result, MessageKeys.WHITESPACE);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/ClassVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ClassVerifier.java
@@ -79,7 +79,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.getAnnotations().length > 0;
 
-        verification().check(result, MessageKeys.ANNOTATED);
+        verification().report(result, MessageKeys.ANNOTATED);
 
         return this;
     }
@@ -109,7 +109,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && type != null && value.isAnnotationPresent(type);
 
-        verification().check(result, MessageKeys.ANNOTATED_WITH, type);
+        verification().report(result, MessageKeys.ANNOTATED_WITH, type);
 
         return this;
     }
@@ -141,7 +141,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && matchAll(types, input -> input != null && value.isAnnotationPresent(input));
 
-        verification().check(result, MessageKeys.ANNOTATED_WITH_ALL, (Object) types);
+        verification().report(result, MessageKeys.ANNOTATED_WITH_ALL, (Object) types);
 
         return this;
     }
@@ -172,7 +172,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && matchAny(types, input -> input != null && value.isAnnotationPresent(input));
 
-        verification().check(result, MessageKeys.ANNOTATED_WITH_ANY, (Object) types);
+        verification().report(result, MessageKeys.ANNOTATED_WITH_ANY, (Object) types);
 
         return this;
     }
@@ -195,7 +195,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isAnnotation();
 
-        verification().check(result, MessageKeys.ANNOTATION);
+        verification().report(result, MessageKeys.ANNOTATION);
 
         return this;
     }
@@ -218,7 +218,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isAnonymousClass();
 
-        verification().check(result, MessageKeys.ANONYMOUS);
+        verification().report(result, MessageKeys.ANONYMOUS);
 
         return this;
     }
@@ -241,7 +241,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isArray();
 
-        verification().check(result, MessageKeys.ARRAY);
+        verification().report(result, MessageKeys.ARRAY);
 
         return this;
     }
@@ -271,7 +271,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && type != null && value.isAssignableFrom(type);
 
-        verification().check(result, MessageKeys.ASSIGNABLE_FROM, type);
+        verification().report(result, MessageKeys.ASSIGNABLE_FROM, type);
 
         return this;
     }
@@ -294,7 +294,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isEnum();
 
-        verification().check(result, MessageKeys.ENUMERATION);
+        verification().report(result, MessageKeys.ENUMERATION);
 
         return this;
     }
@@ -317,7 +317,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isInterface();
 
-        verification().check(result, MessageKeys.INTERFACING);
+        verification().report(result, MessageKeys.INTERFACING);
 
         return this;
     }
@@ -340,7 +340,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.getEnclosingClass() != null;
 
-        verification().check(result, MessageKeys.NESTED);
+        verification().report(result, MessageKeys.NESTED);
 
         return this;
     }
@@ -364,7 +364,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && value.isPrimitive();
 
-        verification().check(result, MessageKeys.PRIMITIVE);
+        verification().report(result, MessageKeys.PRIMITIVE);
 
         return this;
     }
@@ -388,7 +388,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = value != null && (value.isPrimitive() || PRIMITIVE_WRAPPERS.contains(value));
 
-        verification().check(result, MessageKeys.PRIMITIVE_OR_WRAPPER);
+        verification().report(result, MessageKeys.PRIMITIVE_OR_WRAPPER);
 
         return this;
     }
@@ -412,7 +412,7 @@ public final class ClassVerifier extends AbstractCustomVerifier<Class, ClassVeri
         final Class<?> value = verification().getValue();
         final boolean result = PRIMITIVE_WRAPPERS.contains(value);
 
-        verification().check(result, MessageKeys.PRIMITIVE_WRAPPER);
+        verification().report(result, MessageKeys.PRIMITIVE_WRAPPER);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/DoubleVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/DoubleVerifier.java
@@ -58,7 +58,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value % 2D == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value == null || value == 0D;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value < 0D;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value % 2 != 0D;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value == 1D;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value >= 0D;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value == 1D;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class DoubleVerifier extends BaseComparableVerifier<Double, DoubleV
         final Double value = verification().getValue();
         final boolean result = value != null && value == 0D;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/FloatVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/FloatVerifier.java
@@ -58,7 +58,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value % 2F == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value == null || value == 0F;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value < 0F;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value % 2 != 0F;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value == 1F;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value >= 0F;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value == 1F;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class FloatVerifier extends BaseComparableVerifier<Float, FloatVeri
         final Float value = verification().getValue();
         final boolean result = value != null && value == 0F;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/IntegerVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/IntegerVerifier.java
@@ -58,7 +58,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value % 2 == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value == null || value == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value < 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value % 2 != 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value >= 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class IntegerVerifier extends BaseComparableVerifier<Integer, Integ
         final Integer value = verification().getValue();
         final boolean result = value != null && value == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
@@ -72,7 +72,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = LazyHolder.AVAILABLE_LOCALES.contains(value);
 
-        verification().check(result, MessageKeys.AVAILABLE);
+        verification().report(result, MessageKeys.AVAILABLE);
 
         return this;
     }
@@ -102,7 +102,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = value != null && value.getCountry().equals(country);
 
-        verification().check(result, MessageKeys.COUNTRY, country);
+        verification().report(result, MessageKeys.COUNTRY, country);
 
         return this;
     }
@@ -125,7 +125,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = Locale.getDefault().equals(value);
 
-        verification().check(result, MessageKeys.DEFAULTING);
+        verification().report(result, MessageKeys.DEFAULTING);
 
         return this;
     }
@@ -154,7 +154,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = value != null && value.getLanguage().equals(language);
 
-        verification().check(result, MessageKeys.LANGUAGE, language);
+        verification().report(result, MessageKeys.LANGUAGE, language);
 
         return this;
     }
@@ -184,7 +184,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = value != null && value.getScript().equals(script);
 
-        verification().check(result, MessageKeys.SCRIPT, script);
+        verification().report(result, MessageKeys.SCRIPT, script);
 
         return this;
     }
@@ -214,7 +214,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
         final Locale value = verification().getValue();
         final boolean result = value != null && value.getVariant().equals(variant);
 
-        verification().check(result, MessageKeys.VARIANT, variant);
+        verification().report(result, MessageKeys.VARIANT, variant);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/LongVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/LongVerifier.java
@@ -58,7 +58,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value % 2L == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value == null || value == 0L;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value < 0L;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value % 2 != 0L;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value == 1L;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value >= 0L;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value == 1L;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class LongVerifier extends BaseComparableVerifier<Long, LongVerifie
         final Long value = verification().getValue();
         final boolean result = value != null && value == 0L;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/MapVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/MapVerifier.java
@@ -83,7 +83,7 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
         final Map<K, V> value = verification().getValue();
         final boolean result = value != null && matchAll(keys, value::containsKey);
 
-        verification().check(result, MessageKeys.CONTAIN_ALL_KEYS, (Object) keys);
+        verification().report(result, MessageKeys.CONTAIN_ALL_KEYS, (Object) keys);
 
         return this;
     }
@@ -116,7 +116,7 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
         final Map<K, V> value = verification().getValue();
         final boolean result = value != null && matchAny(keys, value::containsKey);
 
-        verification().check(result, MessageKeys.CONTAIN_ANY_KEY, (Object) keys);
+        verification().report(result, MessageKeys.CONTAIN_ANY_KEY, (Object) keys);
 
         return this;
     }
@@ -147,7 +147,7 @@ public final class MapVerifier<K, V> extends BaseCollectionVerifier<V, Map<K, V>
         final Map<K, V> value = verification().getValue();
         final boolean result = value != null && value.containsKey(key);
 
-        verification().check(result, MessageKeys.CONTAIN_KEY, key);
+        verification().report(result, MessageKeys.CONTAIN_KEY, key);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/ShortVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ShortVerifier.java
@@ -58,7 +58,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value % 2 == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.EVEN);
+        verification().report(result, BaseNumberVerifier.MessageKeys.EVEN);
 
         return this;
     }
@@ -68,7 +68,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value == null || value == 0;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -78,7 +78,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value < 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.NEGATIVE);
 
         return this;
     }
@@ -88,7 +88,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value % 2 != 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ODD);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ODD);
 
         return this;
     }
@@ -98,7 +98,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ONE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ONE);
 
         return this;
     }
@@ -108,7 +108,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value >= 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verification().report(result, BaseNumberVerifier.MessageKeys.POSITIVE);
 
         return this;
     }
@@ -118,7 +118,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value == 1;
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -128,7 +128,7 @@ public final class ShortVerifier extends BaseComparableVerifier<Short, ShortVeri
         final Short value = verification().getValue();
         final boolean result = value != null && value == 0;
 
-        verification().check(result, BaseNumberVerifier.MessageKeys.ZERO);
+        verification().report(result, BaseNumberVerifier.MessageKeys.ZERO);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/StringVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/StringVerifier.java
@@ -155,7 +155,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, Character::isLetter);
 
-        verification().check(result, MessageKeys.ALPHA);
+        verification().report(result, MessageKeys.ALPHA);
 
         return this;
     }
@@ -181,7 +181,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, character -> Character.isLetter(character) || character == ' ');
 
-        verification().check(result, MessageKeys.ALPHA_SPACE);
+        verification().report(result, MessageKeys.ALPHA_SPACE);
 
         return this;
     }
@@ -208,7 +208,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, Character::isLetterOrDigit);
 
-        verification().check(result, MessageKeys.ALPHANUMERIC);
+        verification().report(result, MessageKeys.ALPHANUMERIC);
 
         return this;
     }
@@ -234,7 +234,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, character -> Character.isLetterOrDigit(character) || character == ' ');
 
-        verification().check(result, MessageKeys.ALPHANUMERIC_SPACE);
+        verification().report(result, MessageKeys.ALPHANUMERIC_SPACE);
 
         return this;
     }
@@ -258,7 +258,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, character -> character >= 32 && character < 127);
 
-        verification().check(result, MessageKeys.ASCII_PRINTABLE);
+        verification().report(result, MessageKeys.ASCII_PRINTABLE);
 
         return this;
     }
@@ -289,7 +289,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value == null || value.trim().isEmpty();
 
-        verification().check(result, MessageKeys.BLANK);
+        verification().report(result, MessageKeys.BLANK);
 
         return this;
     }
@@ -322,7 +322,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && other != null && value.contains(other);
 
-        verification().check(result, MessageKeys.CONTAIN, other);
+        verification().report(result, MessageKeys.CONTAIN, other);
 
         return this;
     }
@@ -354,7 +354,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAll(others, input -> input != null && value.contains(input));
 
-        verification().check(result, MessageKeys.CONTAIN_ALL, (Object) others);
+        verification().report(result, MessageKeys.CONTAIN_ALL, (Object) others);
 
         return this;
     }
@@ -386,7 +386,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAll(others, input -> containsIgnoreCase(value, input));
 
-        verification().check(result, MessageKeys.CONTAIN_ALL_IGNORE_CASE, (Object) others);
+        verification().report(result, MessageKeys.CONTAIN_ALL_IGNORE_CASE, (Object) others);
 
         return this;
     }
@@ -419,7 +419,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAny(others, input -> input != null && value.contains(input));
 
-        verification().check(result, MessageKeys.CONTAIN_ANY, (Object) others);
+        verification().report(result, MessageKeys.CONTAIN_ANY, (Object) others);
 
         return this;
     }
@@ -452,7 +452,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAny(others, input -> containsIgnoreCase(value, input));
 
-        verification().check(result, MessageKeys.CONTAIN_ANY_IGNORE_CASE, (Object) others);
+        verification().report(result, MessageKeys.CONTAIN_ANY_IGNORE_CASE, (Object) others);
 
         return this;
     }
@@ -485,7 +485,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && containsIgnoreCase(value, other);
 
-        verification().check(result, MessageKeys.CONTAIN_IGNORE_CASE, other);
+        verification().report(result, MessageKeys.CONTAIN_IGNORE_CASE, other);
 
         return this;
     }
@@ -514,7 +514,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value == null || value.isEmpty();
 
-        verification().check(result, MessageKeys.EMPTY);
+        verification().report(result, MessageKeys.EMPTY);
 
         return this;
     }
@@ -547,7 +547,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && endsWith(value, other, false);
 
-        verification().check(result, MessageKeys.END_WITH, other);
+        verification().report(result, MessageKeys.END_WITH, other);
 
         return this;
     }
@@ -579,7 +579,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAny(others, input -> endsWith(value, input, false));
 
-        verification().check(result, MessageKeys.END_WITH_ANY, (Object) others);
+        verification().report(result, MessageKeys.END_WITH_ANY, (Object) others);
 
         return this;
     }
@@ -611,7 +611,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && matchAny(others, input -> endsWith(value, input, true));
 
-        verification().check(result, MessageKeys.END_WITH_ANY_IGNORE_CASE, (Object) others);
+        verification().report(result, MessageKeys.END_WITH_ANY_IGNORE_CASE, (Object) others);
 
         return this;
     }
@@ -644,7 +644,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && endsWith(value, other, true);
 
-        verification().check(result, MessageKeys.END_WITH_IGNORE_CASE, other);
+        verification().report(result, MessageKeys.END_WITH_IGNORE_CASE, other);
 
         return this;
     }
@@ -678,7 +678,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchAny(others, input -> isEqualToIgnoreCase(value, input));
 
-        verification().check(result, MessageKeys.EQUAL_TO_ANY_IGNORE_CASE, (Object) others);
+        verification().report(result, MessageKeys.EQUAL_TO_ANY_IGNORE_CASE, (Object) others);
 
         return chain();
     }
@@ -710,7 +710,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = isEqualToIgnoreCase(value, other);
 
-        verification().check(result, MessageKeys.EQUAL_TO_IGNORE_CASE, other);
+        verification().report(result, MessageKeys.EQUAL_TO_IGNORE_CASE, other);
 
         return this;
     }
@@ -720,7 +720,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value == null || value.isEmpty() || Boolean.FALSE.toString().equalsIgnoreCase(value);
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.FALSY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.FALSY);
 
         return this;
     }
@@ -747,7 +747,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, Character::isLowerCase);
 
-        verification().check(result, MessageKeys.LOWER_CASE);
+        verification().report(result, MessageKeys.LOWER_CASE);
 
         return this;
     }
@@ -778,7 +778,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && regex != null && value.matches(regex.toString());
 
-        verification().check(result, MessageKeys.MATCH, regex);
+        verification().report(result, MessageKeys.MATCH, regex);
 
         return this;
     }
@@ -809,7 +809,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value != null && pattern != null && pattern.matcher(value).matches();
 
-        verification().check(result, MessageKeys.MATCH, pattern);
+        verification().report(result, MessageKeys.MATCH, pattern);
 
         return this;
     }
@@ -836,7 +836,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, Character::isDigit);
 
-        verification().check(result, MessageKeys.NUMERIC);
+        verification().report(result, MessageKeys.NUMERIC);
 
         return this;
     }
@@ -862,7 +862,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, character -> Character.isDigit(character) || character == ' ');
 
-        verification().check(result, MessageKeys.NUMERIC_SPACE);
+        verification().report(result, MessageKeys.NUMERIC_SPACE);
 
         return this;
     }
@@ -894,7 +894,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = value == null ? size == 0 : value.length() == size;
 
-        verification().check(result, MessageKeys.SIZE_OF, size);
+        verification().report(result, MessageKeys.SIZE_OF, size);
 
         return this;
     }
@@ -927,7 +927,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = startsWith(value, other, false);
 
-        verification().check(result, MessageKeys.START_WITH, other);
+        verification().report(result, MessageKeys.START_WITH, other);
 
         return this;
     }
@@ -959,7 +959,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchAny(others, input -> startsWith(value, input, false));
 
-        verification().check(result, MessageKeys.START_WITH_ANY, (Object) others);
+        verification().report(result, MessageKeys.START_WITH_ANY, (Object) others);
 
         return this;
     }
@@ -991,7 +991,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchAny(others, input -> startsWith(value, input, true));
 
-        verification().check(result, MessageKeys.START_WITH_ANY_IGNORE_CASE, (Object) others);
+        verification().report(result, MessageKeys.START_WITH_ANY_IGNORE_CASE, (Object) others);
 
         return this;
     }
@@ -1024,7 +1024,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = startsWith(value, other, true);
 
-        verification().check(result, MessageKeys.START_WITH_IGNORE_CASE, other);
+        verification().report(result, MessageKeys.START_WITH_IGNORE_CASE, other);
 
         return this;
     }
@@ -1034,7 +1034,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = Boolean.TRUE.toString().equalsIgnoreCase(value);
 
-        verification().check(result, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verification().report(result, BaseTruthVerifier.MessageKeys.TRUTHY);
 
         return this;
     }
@@ -1061,7 +1061,7 @@ public final class StringVerifier extends BaseComparableVerifier<String, StringV
         final String value = verification().getValue();
         final boolean result = matchCharacters(value, Character::isUpperCase);
 
-        verification().check(result, MessageKeys.UPPER_CASE);
+        verification().report(result, MessageKeys.UPPER_CASE);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/ThrowableVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/ThrowableVerifier.java
@@ -96,7 +96,7 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
             }
         }
 
-        verification().check(result, MessageKeys.CAUSED_BY, type);
+        verification().report(result, MessageKeys.CAUSED_BY, type);
 
         return this;
     }
@@ -163,7 +163,7 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
         final Throwable value = verification().getValue();
         final boolean result = getThrowables(value).contains(cause);
 
-        verification().check(result, MessageKeys.CAUSED_BY, name);
+        verification().report(result, MessageKeys.CAUSED_BY, name);
 
         return this;
     }
@@ -189,7 +189,7 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
         final Throwable value = verification().getValue();
         final boolean result = value != null && !(value instanceof RuntimeException);
 
-        verification().check(result, MessageKeys.CHECKED);
+        verification().report(result, MessageKeys.CHECKED);
 
         return this;
     }
@@ -221,7 +221,7 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
         final Throwable value = verification().getValue();
         final boolean result = value != null && (value.getMessage() == null ? message == null : value.getMessage().equals(message));
 
-        verification().check(result, MessageKeys.MESSAGE, message);
+        verification().report(result, MessageKeys.MESSAGE, message);
 
         return this;
     }
@@ -247,7 +247,7 @@ public final class ThrowableVerifier extends AbstractCustomVerifier<Throwable, T
         final Throwable value = verification().getValue();
         final boolean result = value instanceof RuntimeException;
 
-        verification().check(result, MessageKeys.UNCHECKED);
+        verification().report(result, MessageKeys.UNCHECKED);
 
         return this;
     }

--- a/src/main/java/io/skelp/verifier/type/base/BaseCollectionVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseCollectionVerifier.java
@@ -85,7 +85,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
         final Collection<E> value = getCollection(verification().getValue());
         final boolean result = value != null && value.contains(element);
 
-        verification().check(result, MessageKeys.CONTAIN, element);
+        verification().report(result, MessageKeys.CONTAIN, element);
 
         return chain();
     }
@@ -118,7 +118,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
         final Collection<E> value = getCollection(verification().getValue());
         final boolean result = value != null && matchAll(elements, value::contains);
 
-        verification().check(result, MessageKeys.CONTAIN_ALL, (Object) elements);
+        verification().report(result, MessageKeys.CONTAIN_ALL, (Object) elements);
 
         return chain();
     }
@@ -151,7 +151,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
         final Collection<E> value = getCollection(verification().getValue());
         final boolean result = value != null && matchAny(elements, value::contains);
 
-        verification().check(result, MessageKeys.CONTAIN_ANY, (Object) elements);
+        verification().report(result, MessageKeys.CONTAIN_ANY, (Object) elements);
 
         return chain();
     }
@@ -177,7 +177,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
         final T value = verification().getValue();
         final boolean result = value == null || getSize(value) == 0;
 
-        verification().check(result, MessageKeys.EMPTY);
+        verification().report(result, MessageKeys.EMPTY);
 
         return chain();
     }
@@ -208,7 +208,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
         final T value = verification().getValue();
         final boolean result = value == null ? size == 0 : getSize(value) == size;
 
-        verification().check(result, MessageKeys.SIZE_OF, size);
+        verification().report(result, MessageKeys.SIZE_OF, size);
 
         return chain();
     }
@@ -241,7 +241,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @see #thatAll(VerifierAssertion, String, Object...)
      */
     public V thatAll(final VerifierAssertion<E> assertion) {
-        verification().check(thatAllInternal(assertion), (String) null);
+        verification().report(thatAllInternal(assertion), (String) null);
 
         return chain();
     }
@@ -273,7 +273,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @since 0.2.0
      */
     public V thatAll(final VerifierAssertion<E> assertion, final MessageKey key, final Object... args) {
-        verification().check(thatAllInternal(assertion), key, args);
+        verification().report(thatAllInternal(assertion), key, args);
 
         return chain();
     }
@@ -303,7 +303,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @see #thatAll(VerifierAssertion, MessageKey, Object...)
      */
     public V thatAll(final VerifierAssertion<E> assertion, final String message, final Object... args) {
-        verification().check(thatAllInternal(assertion), message, args);
+        verification().report(thatAllInternal(assertion), message, args);
 
         return chain();
     }
@@ -364,7 +364,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @see #thatAny(VerifierAssertion, String, Object...)
      */
     public V thatAny(final VerifierAssertion<E> assertion) {
-        verification().check(thatAnyInternal(assertion), (String) null);
+        verification().report(thatAnyInternal(assertion), (String) null);
 
         return chain();
     }
@@ -396,7 +396,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @since 0.2.0
      */
     public V thatAny(final VerifierAssertion<E> assertion, final MessageKey key, final Object... args) {
-        verification().check(thatAnyInternal(assertion), key, args);
+        verification().report(thatAnyInternal(assertion), key, args);
 
         return chain();
     }
@@ -426,7 +426,7 @@ public abstract class BaseCollectionVerifier<E, T, V extends BaseCollectionVerif
      * @see #thatAny(VerifierAssertion, MessageKey, Object...)
      */
     public V thatAny(final VerifierAssertion<E> assertion, final String message, final Object... args) {
-        verification().check(thatAnyInternal(assertion), message, args);
+        verification().report(thatAnyInternal(assertion), message, args);
 
         return chain();
     }

--- a/src/main/java/io/skelp/verifier/type/base/BaseComparableVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseComparableVerifier.java
@@ -455,7 +455,7 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
         final boolean result = value != null && start != null && end != null &&
             (startComparison.compare(value.compareTo(start)) && endComparison.compare(value.compareTo(end)));
 
-        verification().check(result, key, startName, endName);
+        verification().report(result, key, startName, endName);
 
         return chain();
     }
@@ -464,7 +464,7 @@ public abstract class BaseComparableVerifier<T extends Comparable<? super T>, V 
         final T value = verification().getValue();
         final boolean result = (value == null || other == null) ? comparison.areNullsEqual() && value == other : comparison.compare(value.compareTo(other));
 
-        verification().check(result, key, name);
+        verification().report(result, key, name);
 
         return chain();
     }

--- a/src/main/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifier.java
@@ -144,7 +144,7 @@ public abstract class BaseSortableCollectionVerifier<E, T, V extends BaseSortabl
             }
         }
 
-        verification().check(result, MessageKeys.SORTED_BY, name);
+        verification().report(result, MessageKeys.SORTED_BY, name);
 
         return chain();
     }

--- a/src/main/java/io/skelp/verifier/type/base/BaseTimeVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/base/BaseTimeVerifier.java
@@ -83,7 +83,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.YEAR) == calendar2.get(Calendar.YEAR) &&
                 calendar1.get(Calendar.DAY_OF_YEAR) == calendar2.get(Calendar.DAY_OF_YEAR));
 
-        verification().check(result, MessageKeys.SAME_DAY_AS, other);
+        verification().report(result, MessageKeys.SAME_DAY_AS, other);
 
         return chain();
     }
@@ -114,7 +114,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
         final boolean result = calendar1 != null && calendar2 != null &&
             calendar1.get(Calendar.ERA) == calendar2.get(Calendar.ERA);
 
-        verification().check(result, MessageKeys.SAME_ERA_AS, other);
+        verification().report(result, MessageKeys.SAME_ERA_AS, other);
 
         return chain();
     }
@@ -149,7 +149,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.DAY_OF_YEAR) == calendar2.get(Calendar.DAY_OF_YEAR) &&
                 calendar1.get(Calendar.HOUR_OF_DAY) == calendar2.get(Calendar.HOUR_OF_DAY));
 
-        verification().check(result, MessageKeys.SAME_HOUR_AS, other);
+        verification().report(result, MessageKeys.SAME_HOUR_AS, other);
 
         return chain();
     }
@@ -185,7 +185,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.HOUR_OF_DAY) == calendar2.get(Calendar.HOUR_OF_DAY) &&
                 calendar1.get(Calendar.MINUTE) == calendar2.get(Calendar.MINUTE));
 
-        verification().check(result, MessageKeys.SAME_MINUTE_AS, other);
+        verification().report(result, MessageKeys.SAME_MINUTE_AS, other);
 
         return chain();
     }
@@ -219,7 +219,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.YEAR) == calendar2.get(Calendar.YEAR) &&
                 calendar1.get(Calendar.MONTH) == calendar2.get(Calendar.MONTH));
 
-        verification().check(result, MessageKeys.SAME_MONTH_AS, other);
+        verification().report(result, MessageKeys.SAME_MONTH_AS, other);
 
         return chain();
     }
@@ -256,7 +256,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.MINUTE) == calendar2.get(Calendar.MINUTE) &&
                 calendar1.get(Calendar.SECOND) == calendar2.get(Calendar.SECOND));
 
-        verification().check(result, MessageKeys.SAME_SECOND_AS, other);
+        verification().report(result, MessageKeys.SAME_SECOND_AS, other);
 
         return chain();
     }
@@ -288,7 +288,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
         final boolean result = calendar1 != null && calendar2 != null &&
             calendar1.getTimeInMillis() == calendar2.getTimeInMillis();
 
-        verification().check(result, MessageKeys.SAME_TIME_AS, other);
+        verification().report(result, MessageKeys.SAME_TIME_AS, other);
 
         return chain();
     }
@@ -322,7 +322,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
                 calendar1.get(Calendar.YEAR) == calendar2.get(Calendar.YEAR) &&
                 calendar1.get(Calendar.WEEK_OF_YEAR) == calendar2.get(Calendar.WEEK_OF_YEAR));
 
-        verification().check(result, MessageKeys.SAME_WEEK_AS, other);
+        verification().report(result, MessageKeys.SAME_WEEK_AS, other);
 
         return chain();
     }
@@ -355,7 +355,7 @@ public abstract class BaseTimeVerifier<T extends Comparable<? super T>, V extend
             (calendar1.get(Calendar.ERA) == calendar2.get(Calendar.ERA) &&
                 calendar1.get(Calendar.YEAR) == calendar2.get(Calendar.YEAR));
 
-        verification().check(result, MessageKeys.SAME_YEAR_AS, other);
+        verification().report(result, MessageKeys.SAME_YEAR_AS, other);
 
         return chain();
     }

--- a/src/main/java/io/skelp/verifier/verification/DefaultVerificationProvider.java
+++ b/src/main/java/io/skelp/verifier/verification/DefaultVerificationProvider.java
@@ -26,6 +26,8 @@ import io.skelp.verifier.message.MessageSourceProvider;
 import io.skelp.verifier.message.locale.LocaleContext;
 import io.skelp.verifier.message.locale.LocaleContextProvider;
 import io.skelp.verifier.service.Services;
+import io.skelp.verifier.verification.report.ReportExecutor;
+import io.skelp.verifier.verification.report.ReportExecutorProvider;
 
 /**
  * <p>
@@ -42,8 +44,9 @@ public final class DefaultVerificationProvider implements VerificationProvider {
     public <T> Verification<T> getVerification(final T value, final Object name) {
         final LocaleContext localeContext = Services.findFirstNonNullForWeightedService(LocaleContextProvider.class, LocaleContextProvider::getLocaleContext);
         final MessageSource messageSource = Services.findFirstNonNullForWeightedService(MessageSourceProvider.class, MessageSourceProvider::getMessageSource);
+        final ReportExecutor reportExecutor = Services.findFirstNonNullForWeightedService(ReportExecutorProvider.class, ReportExecutorProvider::getReportExecutor);
 
-        return new SimpleVerification<>(localeContext, messageSource, value, name);
+        return new SimpleVerification<>(localeContext, messageSource, reportExecutor, value, name);
     }
 
     @Override

--- a/src/main/java/io/skelp/verifier/verification/Verification.java
+++ b/src/main/java/io/skelp/verifier/verification/Verification.java
@@ -25,6 +25,9 @@ import io.skelp.verifier.VerifierException;
 import io.skelp.verifier.message.MessageKey;
 import io.skelp.verifier.message.MessageSource;
 import io.skelp.verifier.message.locale.LocaleContext;
+import io.skelp.verifier.verification.report.AssertionReporter;
+import io.skelp.verifier.verification.report.ReportExecutor;
+import io.skelp.verifier.verification.report.Reporter;
 
 /**
  * <p>
@@ -44,13 +47,14 @@ public interface Verification<T> {
 
     /**
      * <p>
-     * Checks the specified {@code result} to determine whether it passes verification.
+     * Reports the specified {@code result}, which may determine whether it passes verification.
      * </p>
      * <p>
-     * {@code result} will pass it is {@literal true} and this {@link Verification} has not be negated or if it has been
-     * negated and {@code result} is {@literal false}. If it does not pass, a {@link VerifierException} will be thrown
-     * with a suitable localized message, which can be enhanced by providing an optional {@code key} and format
-     * {@code args}.
+     * The {@code result} will pass depending on the {@link Reporter Reporters}. That said; generally, the default
+     * reporter ({@link AssertionReporter}) will pass {@code result} if it is {@literal true} and this
+     * {@link Verification} has not be negated or if it has been negated and {@code result} is {@literal false}. If it
+     * does not pass, a {@link VerifierException} will be thrown with a suitable localized message, which can be
+     * enhanced by providing an optional {@code key} and format {@code args}.
      * </p>
      * <p>
      * This {@link Verification} will no longer be negated as a result of calling this method, regardless of whether
@@ -66,20 +70,22 @@ public interface Verification<T> {
      *         the optional format arguments which are used to format the localized message
      * @return A reference to this {@link Verification} for chaining purposes.
      * @throws VerifierException
-     *         If {@code result} does not pass verification or if a problem occurs while formatting the error message.
-     * @see #check(boolean, String, Object...)
+     *         If any {@link Reporter} deems that {@code result} should not pass verification.
+     * @see #report(boolean, String, Object...)
      * @since 0.2.0
      */
-    Verification<T> check(boolean result, MessageKey key, Object... args);
+    Verification<T> report(boolean result, MessageKey key, Object... args);
 
     /**
      * <p>
-     * Checks the specified {@code result} to determine whether it passes verification.
+     * Reports the specified {@code result}, which may determine whether it passes verification.
      * </p>
      * <p>
-     * {@code result} will pass it is {@literal true} and this {@link Verification} has not be negated or if it has been
-     * negated and {@code result} is {@literal false}. If it does not pass, a {@link VerifierException} will be thrown
-     * with a suitable message, which can be enhanced by providing an optional {@code message} and format {@code args}.
+     * The {@code result} will pass depending on the {@link Reporter Reporters}. That said; generally, the default
+     * reporter ({@link AssertionReporter}) will pass {@code result} if it is {@literal true} and this
+     * {@link Verification} has not be negated or if it has been negated and {@code result} is {@literal false}. If it
+     * does not pass, a {@link VerifierException} will be thrown with a suitable localized message, which can be
+     * enhanced by providing an optional (unlocalized) {@code message} and format {@code args}.
      * </p>
      * <p>
      * This {@link Verification} will no longer be negated as a result of calling this method, regardless of whether
@@ -94,15 +100,16 @@ public interface Verification<T> {
      *         the optional format arguments which are used to format {@code message}
      * @return A reference to this {@link Verification} for chaining purposes.
      * @throws VerifierException
-     *         If {@code result} does not pass verification or if a problem occurs while formatting the error message.
-     * @see #check(boolean, MessageKey, Object...)
+     *         If any {@link Reporter} deems that {@code result} should not pass verification.
+     * @see #report(boolean, MessageKey, Object...)
+     * @since 0.2.0
      */
-    Verification<T> check(boolean result, String message, Object... args);
+    Verification<T> report(boolean result, String message, Object... args);
 
     /**
      * <p>
      * Returns the {@link LocaleContext} that is being used by this {@link Verification} to lookup and format messages
-     * for any {@link VerifierException VerifierExceptions} that are thrown by {@link #check}.
+     * for any {@link VerifierException VerifierExceptions} that are thrown by a {@link Reporter}.
      * </p>
      *
      * @return The {@link LocaleContext}.
@@ -113,7 +120,7 @@ public interface Verification<T> {
     /**
      * <p>
      * Returns the message source that is being used by this {@link Verification} to lookup and/or format the messages
-     * for any {@link VerifierException VerifierExceptions} that are thrown by {@link #check}.
+     * for any {@link VerifierException VerifierExceptions} that are thrown by a {@link Reporter}.
      * </p>
      *
      * @return The {@link MessageSource}.
@@ -132,8 +139,7 @@ public interface Verification<T> {
 
     /**
      * <p>
-     * Returns whether the next result that is passed to {@link #check(boolean, String, Object...)} is negated for this
-     * {@link Verification}.
+     * Returns whether the next result that is passed to {@link #report} is negated for this {@link Verification}.
      * </p>
      *
      * @return {@literal true} if the next result will be negated; otherwise {@literal false}.
@@ -142,14 +148,25 @@ public interface Verification<T> {
 
     /**
      * <p>
-     * Sets whether the next result that is passed to {@link #check(boolean, String, Object...)} is negated for this
-     * {@link Verification} to {@code negated}.
+     * Sets whether the next result that is passed to {@link #report} is negated for this {@link Verification} to
+     * {@code negated}.
      * </p>
      *
      * @param negated
      *         {@literal true} to negate the next result; otherwise {@literal false}
      */
     void setNegated(boolean negated);
+
+    /**
+     * <p>
+     * Returns the report executor that is being used by this {@link Verification} to execute {@link Reporter Reporters}
+     * for a verification result.
+     * </p>
+     *
+     * @return The {@link ReportExecutor}.
+     * @since 0.2.0
+     */
+    ReportExecutor getReportExecutor();
 
     /**
      * <p>

--- a/src/main/java/io/skelp/verifier/verification/VerificationProvider.java
+++ b/src/main/java/io/skelp/verifier/verification/VerificationProvider.java
@@ -29,6 +29,16 @@ import io.skelp.verifier.service.Weighted;
  * Provides {@link Verification} instances to be used to provide context to verifications based on a given value and
  * optional name.
  * </p>
+ * <p>
+ * {@code VerificationProviders} are registered via Java's SPI, so in order to register a custom
+ * {@code VerificationProvider} projects should contain should create a
+ * {@code io.skelp.verifier.verification.verification.VerificationProvider} file within {@code META-INF/services}
+ * listing the class reference for each custom {@code VerificationProvider} (e.g.
+ * {@code com.example.verifier.MyCustomVerificationProvider}) on separate lines. {@code VerificationProviders} are also
+ * {@link Weighted}, which means that they are loaded in priority order (the lower the weight, the higher the priority).
+ * Verifier has a built-in default {@code VerificationProvider} which is given a low priority (i.e.
+ * {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow custom implementations to be easily ordered around it.
+ * </p>
  *
  * @author Alasdair Mercer
  * @since 0.2.0

--- a/src/main/java/io/skelp/verifier/verification/report/AbstractReportExecutor.java
+++ b/src/main/java/io/skelp/verifier/verification/report/AbstractReportExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * An abstract implementation of {@link AbstractReportExecutor} that implements
+ * {@link #execute(Verification, boolean, MessageHolder)} to meet the contract while only requiring implementations to
+ * provide the list of {@link Reporter Reporters} to be executed.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public abstract class AbstractReportExecutor implements ReportExecutor {
+
+    @Override
+    public void execute(final Verification<?> verification, final boolean result, final MessageHolder messageHolder) {
+        for (final Reporter reporter : getReporters()) {
+            if (!reporter.report(verification, result, messageHolder)) {
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/io/skelp/verifier/verification/report/AssertionReporter.java
+++ b/src/main/java/io/skelp/verifier/verification/report/AssertionReporter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * An implementation of {@link Reporter} that simply asserts that the given result passes verification.
+ * </p>
+ * <p>
+ * Basically, a {@link VerifierException} will be thrown in the following cases:
+ * </p>
+ * <ul>
+ * <li>Result is {@literal true} and the {@link Verification} is negated</li>
+ * <li>Result is {@literal false} and the {@link Verification} is <b>not</b> negated</li>
+ * </ul>
+ * <p>
+ * For this reason, this is the ideal {@link Reporter} to be last in the chain as it does what Verifier was designed to
+ * do.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public final class AssertionReporter implements Reporter {
+
+    @Override
+    public boolean report(final Verification<?> verification, final boolean result, final MessageHolder messageHolder) {
+        if (result && verification.isNegated() || !result && !verification.isNegated()) {
+            throw new VerifierException(messageHolder.getMessage(verification));
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getWeight() {
+        return DEFAULT_IMPLEMENTATION_WEIGHT;
+    }
+}

--- a/src/main/java/io/skelp/verifier/verification/report/DefaultReportExecutorProvider.java
+++ b/src/main/java/io/skelp/verifier/verification/report/DefaultReportExecutorProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import java.util.List;
+
+import io.skelp.verifier.service.Services;
+
+/**
+ * <p>
+ * The default implementation of {@link ReportExecutorProvider} which provides an instance of
+ * {@link SimpleReportExecutor} populated with all discoverable {@link Reporter Reporters}.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public final class DefaultReportExecutorProvider implements ReportExecutorProvider {
+
+    @Override
+    public ReportExecutor getReportExecutor() {
+        final List<Reporter> reporters = Services.getWeightedServices(Reporter.class);
+
+        return new SimpleReportExecutor(reporters);
+    }
+
+    @Override
+    public int getWeight() {
+        return DEFAULT_IMPLEMENTATION_WEIGHT;
+    }
+}

--- a/src/main/java/io/skelp/verifier/verification/report/KeyMessageHolder.java
+++ b/src/main/java/io/skelp/verifier/verification/report/KeyMessageHolder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.message.MessageKey;
+import io.skelp.verifier.message.MessageSource;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * An immutable implementation of {@link MessageHolder} that contains the {@link MessageKey} relating to a localized
+ * message message and format arguments which are later passed to
+ * {@link MessageSource#getMessage(Verification, MessageKey, Object[])}.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public final class KeyMessageHolder implements MessageHolder {
+
+    private final Object[] args;
+    private final MessageKey key;
+
+    /**
+     * <p>
+     * Creates an instance of {@link KeyMessageHolder} for the optional message {@code key} and format {@code args}
+     * provided.
+     * </p>
+     *
+     * @param key
+     *         the optional {@link MessageKey} which provides a more detailed localized explanation of what was
+     *         verified
+     * @param args
+     *         the optional format arguments which are used to format the localized message
+     */
+    public KeyMessageHolder(final MessageKey key, final Object[] args) {
+        this.key = key;
+        this.args = args;
+    }
+
+    @Override
+    public String getMessage(final Verification<?> verification) {
+        return verification.getMessageSource().getMessage(verification, key, args);
+    }
+}

--- a/src/main/java/io/skelp/verifier/verification/report/MessageHolder.java
+++ b/src/main/java/io/skelp/verifier/verification/report/MessageHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Holds a verification message to be retrieved as and when needed as a complete error message.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public interface MessageHolder {
+
+    /**
+     * <p>
+     * Returns the complete error message being held by this {@link MessageHolder}.
+     * </p>
+     *
+     * @param verification
+     *         the current {@link Verification}
+     * @return The complete error message.
+     * @throws VerifierException
+     *         If a problem occurs while trying to retrieve the message.
+     */
+    String getMessage(Verification<?> verification);
+}

--- a/src/main/java/io/skelp/verifier/verification/report/ReportExecutor.java
+++ b/src/main/java/io/skelp/verifier/verification/report/ReportExecutor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import java.util.List;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Responsible for executing a chain of {@link Reporter Reporters} one after the other.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public interface ReportExecutor {
+
+    /**
+     * <p>
+     * Executes all of the {@link Reporter Reporters} for this {@link ReportExecutor} sequentially with the information
+     * provided.
+     * </p>
+     * <p>
+     * Any of the {@link Reporter Reporters} may throw a {@link VerifierException} with a suitable message held in the
+     * {@code messageHolder} provided should they deem that {@code result} does not pass verification, breaking the
+     * chain, meaning none of the remaining {@link Reporter Reporters} within the chain will be executed. The chain can
+     * also be broken should {@link Reporter#report(Verification, boolean, MessageHolder)} return {@literal false} at
+     * any time.
+     * </p>
+     *
+     * @param verification
+     *         the current {@link Verification}
+     * @param result
+     *         the result of the verification to be reported
+     * @param messageHolder
+     *         the {@link MessageHolder} containing the optional message which provides a more detailed explanation of
+     *         what was verified
+     * @throws VerifierException
+     *         If any of the {@link Reporter Reporters} deem that {@code result} should not pass for verification.
+     */
+    void execute(Verification<?> verification, boolean result, MessageHolder messageHolder);
+
+    /**
+     * <p>
+     * Returns the reporters to be executed by this {@link ReportExecutor}.
+     * </p>
+     *
+     * @return The {@code List} of {@link Reporter Reporters} to be executed.
+     */
+    List<Reporter> getReporters();
+}

--- a/src/main/java/io/skelp/verifier/verification/report/ReportExecutorProvider.java
+++ b/src/main/java/io/skelp/verifier/verification/report/ReportExecutorProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.service.Weighted;
+
+/**
+ * <p>
+ * Provides {@link ReportExecutor} instances to be used to execute {@link Reporter Reporters} for a given verification
+ * result, potentially to determine whether it passes.
+ * </p>
+ * <p>
+ * {@code ReportExecutorProviders} are registered via Java's SPI, so in order to register a custom
+ * {@code ReportExecutorProvider} projects should contain should create a
+ * {@code io.skelp.verifier.verification.report.ReportExecutorProvider} file within {@code META-INF/services} listing
+ * the class reference for each custom {@code ReportExecutorProvider} (e.g.
+ * {@code com.example.verifier.MyCustomReportExecutorProvider}) on separate lines. {@code ReportExecutorProviders} are
+ * also {@link Weighted}, which means that they are loaded in priority order (the lower the weight, the higher the
+ * priority). Verifier has a built-in default {@code ReportExecutorProvider} which is given a low priority (i.e.
+ * {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow custom implementations to be easily ordered around it.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public interface ReportExecutorProvider extends Weighted {
+
+    /**
+     * <p>
+     * Returns an instance of {@link ReportExecutor}.
+     * </p>
+     *
+     * @return The {@link ReportExecutor} instance.
+     * @throws VerifierException
+     *         If a problem occurs while providing the {@link ReportExecutor} instance.
+     */
+    ReportExecutor getReportExecutor();
+}

--- a/src/main/java/io/skelp/verifier/verification/report/Reporter.java
+++ b/src/main/java/io/skelp/verifier/verification/report/Reporter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.service.Weighted;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Reports a given result, which may determine whether it passes verification, which are generally executed via a
+ * {@link ReportExecutor}. It should not modify the state of the {@link Verification} in any way.
+ * </p>
+ * <p>
+ * If a {@code Reporter} determines that the result has not passed verification, then it should throw a
+ * {@link VerifierException} with a suitable message provided by a {@link MessageHolder}. However they are not required
+ * to determine whether the verification has passed and can report differently instead (e.g. logging, profiling).
+ * </p>
+ * <p>
+ * When a {@code Reporter} is executed by a {@link ReportExecutor}, it can control whether the next {@code Reporter} in
+ * the chain gets executed.
+ * </p>
+ * <p>
+ * {@code Reporters} are registered via Java's SPI, so in order to register a custom {@code Reporter} projects should
+ * contain should create a {@code io.skelp.verifier.verification.report.Reporter} file within {@code META-INF/services}
+ * listing the class reference for each custom {@code Reporter} (e.g. {@code com.example.verifier.MyCustomReporter}) on
+ * separate lines. {@code Reporters} are also {@link Weighted}, which means that they are loaded in priority order (the
+ * lower the weight, the higher the priority). Verifier has a built-in default {@code Reporter} which is given a low
+ * priority (i.e. {@value #DEFAULT_IMPLEMENTATION_WEIGHT}) to allow custom implementations to be easily ordered around
+ * it.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public interface Reporter extends Weighted {
+
+    /**
+     * <p>
+     * Reports the specified {@code result}, which may determine whether it passes for the given verification.
+     * </p>
+     * <p>
+     * If this {@link Reporter} determines that {@code result} has not passed verification, a {@link VerifierException}
+     * will be thrown with a suitable message held in the {@code messageHolder} provided.
+     * </p>
+     * <p>
+     * When this method is invoked by a {@link ReportExecutor}, the value returned by this method can be used to control
+     * whether the next {@link Reporter} in the chain is executed.
+     * </p>
+     *
+     * @param verification
+     *         the current {@link Verification}
+     * @param result
+     *         the result of the verification
+     * @param messageHolder
+     *         the {@link MessageHolder} containing the optional message which provides a more detailed explanation of
+     *         what was verified
+     * @return {@literal true} if the next {@link Reporter} in the chain of the {@link ReportExecutor} should be
+     * executed; otherwise {@literal false}.
+     * @throws VerifierException
+     *         If deemed that {@code result} should not pass for verification.
+     */
+    boolean report(Verification<?> verification, boolean result, MessageHolder messageHolder);
+}

--- a/src/main/java/io/skelp/verifier/verification/report/SimpleReportExecutor.java
+++ b/src/main/java/io/skelp/verifier/verification/report/SimpleReportExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>
+ * A simple immutable implementation of {@link ReportExecutor}.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public final class SimpleReportExecutor extends AbstractReportExecutor {
+
+    private final List<Reporter> reporters;
+
+    /**
+     * <p>
+     * Creates an instance of {@link SimpleReportExecutor} for the {@code reporters} provided.
+     * </p>
+     *
+     * @param reporters
+     *         the {@code List} of {@link Reporter Reporters} to be used
+     */
+    public SimpleReportExecutor(final List<Reporter> reporters) {
+        this.reporters = new ArrayList<>(reporters);
+    }
+
+    @Override
+    public List<Reporter> getReporters() {
+        return reporters;
+    }
+}

--- a/src/main/java/io/skelp/verifier/verification/report/StringMessageHolder.java
+++ b/src/main/java/io/skelp/verifier/verification/report/StringMessageHolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import io.skelp.verifier.message.MessageSource;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * An immutable implementation of {@link MessageHolder} that contains an unlocalized string message and format arguments
+ * which are later passed to {@link MessageSource#getMessage(Verification, String, Object[])}.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ * @since 0.2.0
+ */
+public final class StringMessageHolder implements MessageHolder {
+
+    private final Object[] args;
+    private final String message;
+
+    /**
+     * <p>
+     * Creates an instance of {@link StringMessageHolder} for the optional {@code message} and format {@code args}
+     * provided.
+     * </p>
+     *
+     * @param message
+     *         the optional message which provides a more detailed explanation of what was verified
+     * @param args
+     *         the optional format arguments which are used to format {@code message}
+     */
+    public StringMessageHolder(final String message, final Object[] args) {
+        this.message = message;
+        this.args = args;
+    }
+
+    @Override
+    public String getMessage(final Verification<?> verification) {
+        return verification.getMessageSource().getMessage(verification, message, args);
+    }
+}

--- a/src/main/resources/META-INF/services/io.skelp.verifier.verification.report.ReportExecutorProvider
+++ b/src/main/resources/META-INF/services/io.skelp.verifier.verification.report.ReportExecutorProvider
@@ -1,0 +1,1 @@
+io.skelp.verifier.verification.report.DefaultReportExecutorProvider

--- a/src/main/resources/META-INF/services/io.skelp.verifier.verification.report.Reporter
+++ b/src/main/resources/META-INF/services/io.skelp.verifier.verification.report.Reporter
@@ -1,0 +1,1 @@
+io.skelp.verifier.verification.report.AssertionReporter

--- a/src/test/java/io/skelp/verifier/AbstractCustomVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/AbstractCustomVerifierTestCase.java
@@ -86,7 +86,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().equalTo(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -128,7 +128,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().equalTo(other, name));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes name for message formatting", name, getArgsCaptor().getValue());
     }
@@ -185,7 +185,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().equalToAny(others));
 
-        verify(getMockVerification()).check(expected, AbstractCustomVerifier.MessageKeys.EQUAL_TO_ANY, (Object) others);
+        verify(getMockVerification()).report(expected, AbstractCustomVerifier.MessageKeys.EQUAL_TO_ANY, (Object) others);
     }
 
     @Test
@@ -212,7 +212,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().hashedAs(hashCode));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.HASHED_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.HASHED_AS), getArgsCaptor().capture());
 
         assertEquals("Passes hash code for message formatting", hashCode, getArgsCaptor().getValue());
     }
@@ -252,7 +252,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().instanceOf(cls));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.INSTANCE_OF), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.INSTANCE_OF), getArgsCaptor().capture());
 
         assertEquals("Passes class for message formatting", cls, getArgsCaptor().getValue());
     }
@@ -307,7 +307,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().instanceOfAll(classes));
 
-        verify(getMockVerification()).check(expected, AbstractCustomVerifier.MessageKeys.INSTANCE_OF_ALL, (Object) classes);
+        verify(getMockVerification()).report(expected, AbstractCustomVerifier.MessageKeys.INSTANCE_OF_ALL, (Object) classes);
     }
 
     @Test
@@ -360,7 +360,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().instanceOfAny(classes));
 
-        verify(getMockVerification()).check(expected, AbstractCustomVerifier.MessageKeys.INSTANCE_OF_ANY, (Object) classes);
+        verify(getMockVerification()).report(expected, AbstractCustomVerifier.MessageKeys.INSTANCE_OF_ANY, (Object) classes);
     }
 
     @Test
@@ -394,7 +394,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().nulled());
 
-        verify(getMockVerification()).check(expected, AbstractCustomVerifier.MessageKeys.NULLED);
+        verify(getMockVerification()).report(expected, AbstractCustomVerifier.MessageKeys.NULLED);
     }
 
     @Test
@@ -434,7 +434,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.SAME_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.SAME_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -476,7 +476,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameAs(other, name));
 
-        verify(getMockVerification()).check(eq(expected), eq(AbstractCustomVerifier.MessageKeys.SAME_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(AbstractCustomVerifier.MessageKeys.SAME_AS), getArgsCaptor().capture());
 
         assertSame("Passes name for message formatting", name, getArgsCaptor().getValue());
     }
@@ -533,7 +533,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameAsAny(others));
 
-        verify(getMockVerification()).check(expected, AbstractCustomVerifier.MessageKeys.SAME_AS_ANY, (Object) others);
+        verify(getMockVerification()).report(expected, AbstractCustomVerifier.MessageKeys.SAME_AS_ANY, (Object) others);
     }
 
     @Test
@@ -563,7 +563,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().that(mockAssertion));
 
         verify(mockAssertion).verify(value);
-        verify(getMockVerification()).check(eq(expected), isNull(String.class));
+        verify(getMockVerification()).report(eq(expected), isNull(String.class));
     }
 
     @Test
@@ -593,7 +593,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().that(mockAssertion, message, args));
 
         verify(mockAssertion).verify(value);
-        verify(getMockVerification()).check(eq(expected), eq(message), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(message), getArgsCaptor().capture());
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());
     }
@@ -625,7 +625,7 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().that(mockAssertion, key, args));
 
         verify(mockAssertion).verify(value);
-        verify(getMockVerification()).check(eq(expected), eq(key), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(key), getArgsCaptor().capture());
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());
     }

--- a/src/test/java/io/skelp/verifier/CustomVerifierTestCaseBase.java
+++ b/src/test/java/io/skelp/verifier/CustomVerifierTestCaseBase.java
@@ -44,6 +44,8 @@ import io.skelp.verifier.verification.SimpleVerification;
 import io.skelp.verifier.verification.TestVerificationProvider;
 import io.skelp.verifier.verification.Verification;
 import io.skelp.verifier.verification.VerificationProvider;
+import io.skelp.verifier.verification.report.DefaultReportExecutorProvider;
+import io.skelp.verifier.verification.report.ReportExecutor;
 
 /**
  * <p>
@@ -126,6 +128,8 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
     @Mock
     private MessageSource mockMessageSource;
     @Mock
+    private ReportExecutor mockReportExecutor;
+    @Mock
     private Verification<T> mockVerification;
     @Mock
     private VerificationProvider mockVerificationProvider;
@@ -136,12 +140,13 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
 
     @Before
     public void setUp() throws Exception {
-        when(mockVerificationProvider.getVerification(any(), any())).thenAnswer(invocation -> new SimpleVerification<>(new SimpleLocaleContext(), new ResourceBundleMessageSource(), invocation.getArguments()[0], invocation.getArguments()[1]));
+        when(mockVerificationProvider.getVerification(any(), any())).thenAnswer(invocation -> new SimpleVerification<>(new SimpleLocaleContext(), new ResourceBundleMessageSource(), new DefaultReportExecutorProvider().getReportExecutor(), invocation.getArguments()[0], invocation.getArguments()[1]));
 
         TestVerificationProvider.setDelegate(mockVerificationProvider);
 
         when(mockVerification.getLocaleContext()).thenReturn(mockLocaleContext);
         when(mockVerification.getMessageSource()).thenReturn(mockMessageSource);
+        when(mockVerification.getReportExecutor()).thenReturn(mockReportExecutor);
         when(mockVerification.getValue()).thenAnswer(invocation -> value);
 
         value = null;
@@ -165,8 +170,7 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
 
     /**
      * <p>
-     * Returns an argument captor to be be used to capture any varargs that are passed to {@link
-     * Verification#check(boolean, String, Object...)}.
+     * Returns an argument captor to be be used to capture any varargs that are passed to {@link Verification#report}.
      * </p>
      *
      * @return An {@code ArgumentCaptor} to be used to capture optional format arguments.
@@ -206,6 +210,17 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
      */
     protected MessageSource getMockMessageSource() {
         return mockMessageSource;
+    }
+
+    /**
+     * <p>
+     * Returns the mock report executor being used to test the subject.
+     * </p>
+     *
+     * @return The mock {@link ReportExecutor}.
+     */
+    protected ReportExecutor getMockReportExecutor() {
+        return mockReportExecutor;
     }
 
     /**

--- a/src/test/java/io/skelp/verifier/DefaultCustomVerifierProviderTest.java
+++ b/src/test/java/io/skelp/verifier/DefaultCustomVerifierProviderTest.java
@@ -39,6 +39,7 @@ import io.skelp.verifier.verification.SimpleVerification;
 import io.skelp.verifier.verification.TestVerificationProvider;
 import io.skelp.verifier.verification.Verification;
 import io.skelp.verifier.verification.VerificationProvider;
+import io.skelp.verifier.verification.report.DefaultReportExecutorProvider;
 
 /**
  * <p>
@@ -59,7 +60,7 @@ public class DefaultCustomVerifierProviderTest {
 
     @Before
     public void setUp() {
-        when(mockVerificationProvider.getVerification(any(), any())).thenAnswer(invocation -> new SimpleVerification<>(new SimpleLocaleContext(Locale.ENGLISH), new ResourceBundleMessageSource(), invocation.getArguments()[0], invocation.getArguments()[1]));
+        when(mockVerificationProvider.getVerification(any(), any())).thenAnswer(invocation -> new SimpleVerification<>(new SimpleLocaleContext(Locale.ENGLISH), new ResourceBundleMessageSource(), new DefaultReportExecutorProvider().getReportExecutor(), invocation.getArguments()[0], invocation.getArguments()[1]));
 
         TestVerificationProvider.setDelegate(mockVerificationProvider);
 

--- a/src/test/java/io/skelp/verifier/message/AbstractMessageSourceTestCase.java
+++ b/src/test/java/io/skelp/verifier/message/AbstractMessageSourceTestCase.java
@@ -400,7 +400,7 @@ public abstract class AbstractMessageSourceTestCase<T extends AbstractMessageSou
 
     @Test(expected = NoSuchMessageException.class)
     public void testGetMessageWithMessageKeyThrowsWhenMessageNotFound() throws Exception {
-        messageSource.getMessage(mockVerification, (MessageKey) null);
+        messageSource.getMessage(mockVerification, getMissingMessageKey(), null);
     }
 
     private void testGetMessageWithMessageKeyHelper(MessageKey key, Object[] args, boolean useKeyAsDefaultMessage, boolean negated, String expected) {

--- a/src/test/java/io/skelp/verifier/type/BooleanVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/BooleanVerifierTest.java
@@ -88,7 +88,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().between(false, true));
 
-            verify(getMockVerification()).check(eq(true), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(true), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
 
             assertArrayEquals("Passes start and end for message formatting", new Object[]{false, true}, getArgsCaptor().getAllValues().toArray());
         }
@@ -108,7 +108,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().betweenExclusive(false, true));
 
-            verify(getMockVerification()).check(eq(false), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(false), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
 
             assertArrayEquals("Passes start and end for message formatting", new Object[]{false, true}, getArgsCaptor().getAllValues().toArray());
         }
@@ -133,7 +133,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThan(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -158,7 +158,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThanOrEqualTo(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -183,7 +183,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThan(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -208,7 +208,7 @@ public class BooleanVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThanOrEqualTo(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }

--- a/src/test/java/io/skelp/verifier/type/CharacterVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/CharacterVerifierTest.java
@@ -212,7 +212,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alpha());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ALPHA);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ALPHA);
         }
 
         @Test
@@ -262,7 +262,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alphanumeric());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ALPHANUMERIC);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ALPHANUMERIC);
         }
 
         @Test
@@ -312,7 +312,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().ascii());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII);
         }
 
         @Test
@@ -362,7 +362,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiAlpha());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA);
         }
 
         @Test
@@ -412,7 +412,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiAlphaLowerCase());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA_LOWER_CASE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA_LOWER_CASE);
         }
 
         @Test
@@ -462,7 +462,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiAlphaUpperCase());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA_UPPER_CASE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_ALPHA_UPPER_CASE);
         }
 
         @Test
@@ -512,7 +512,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiAlphanumeric());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_ALPHANUMERIC);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_ALPHANUMERIC);
         }
 
         @Test
@@ -562,7 +562,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiControl());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_CONTROL);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_CONTROL);
         }
 
         @Test
@@ -612,7 +612,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiNumeric());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_NUMERIC);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_NUMERIC);
         }
 
         @Test
@@ -667,7 +667,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiPrintable());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.ASCII_PRINTABLE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.ASCII_PRINTABLE);
         }
 
         @Test
@@ -722,7 +722,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lowerCase());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.LOWER_CASE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.LOWER_CASE);
         }
 
         @Test
@@ -777,7 +777,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().numeric());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.NUMERIC);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.NUMERIC);
         }
 
         @Test
@@ -832,7 +832,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().upperCase());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.UPPER_CASE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.UPPER_CASE);
         }
 
         @Test
@@ -882,7 +882,7 @@ public class CharacterVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().whitespace());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, CharacterVerifier.MessageKeys.WHITESPACE);
+            verify(getMockVerification(), times(values.length)).report(expected, CharacterVerifier.MessageKeys.WHITESPACE);
         }
 
         @Override

--- a/src/test/java/io/skelp/verifier/type/ClassVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/ClassVerifierTest.java
@@ -115,7 +115,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().annotated());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ANNOTATED);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ANNOTATED);
         }
 
         @Test
@@ -153,7 +153,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().annotatedWith(type));
 
-            verify(getMockVerification()).check(eq(expected), eq(ClassVerifier.MessageKeys.ANNOTATED_WITH), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ClassVerifier.MessageKeys.ANNOTATED_WITH), getArgsCaptor().capture());
 
             assertSame("Passes type for message formatting", type, getArgsCaptor().getValue());
         }
@@ -208,7 +208,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().annotatedWithAll(types));
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ANNOTATED_WITH_ALL, (Object) types);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ANNOTATED_WITH_ALL, (Object) types);
         }
 
         @Test
@@ -261,7 +261,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().annotatedWithAny(types));
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ANNOTATED_WITH_ANY, (Object) types);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ANNOTATED_WITH_ANY, (Object) types);
         }
 
         @Test
@@ -284,7 +284,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().annotation());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ANNOTATION);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ANNOTATION);
         }
 
         @Test
@@ -308,7 +308,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().anonymous());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ANONYMOUS);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ANONYMOUS);
         }
 
         @Test
@@ -331,7 +331,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().array());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ARRAY);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ARRAY);
         }
 
         @Test
@@ -364,7 +364,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().assignableFrom(type));
 
-            verify(getMockVerification()).check(eq(expected), eq(ClassVerifier.MessageKeys.ASSIGNABLE_FROM), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ClassVerifier.MessageKeys.ASSIGNABLE_FROM), getArgsCaptor().capture());
 
             assertSame("Passes type for message formatting", type, getArgsCaptor().getValue());
         }
@@ -389,7 +389,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().enumeration());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.ENUMERATION);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.ENUMERATION);
         }
 
         @Test
@@ -412,7 +412,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().interfacing());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.INTERFACING);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.INTERFACING);
         }
 
         @Test
@@ -435,7 +435,7 @@ public class ClassVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().nested());
 
-            verify(getMockVerification()).check(expected, ClassVerifier.MessageKeys.NESTED);
+            verify(getMockVerification()).report(expected, ClassVerifier.MessageKeys.NESTED);
         }
 
         @Test
@@ -468,7 +468,7 @@ public class ClassVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().primitive());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, ClassVerifier.MessageKeys.PRIMITIVE);
+            verify(getMockVerification(), times(values.length)).report(expected, ClassVerifier.MessageKeys.PRIMITIVE);
         }
 
         @Test
@@ -498,7 +498,7 @@ public class ClassVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().primitiveOrWrapper());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, ClassVerifier.MessageKeys.PRIMITIVE_OR_WRAPPER);
+            verify(getMockVerification(), times(values.length)).report(expected, ClassVerifier.MessageKeys.PRIMITIVE_OR_WRAPPER);
         }
 
         @Test
@@ -531,7 +531,7 @@ public class ClassVerifierTest {
                 assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().primitiveWrapper());
             }
 
-            verify(getMockVerification(), times(values.length)).check(expected, ClassVerifier.MessageKeys.PRIMITIVE_WRAPPER);
+            verify(getMockVerification(), times(values.length)).report(expected, ClassVerifier.MessageKeys.PRIMITIVE_WRAPPER);
         }
     }
 

--- a/src/test/java/io/skelp/verifier/type/LocaleVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/LocaleVerifierTest.java
@@ -162,7 +162,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().available());
 
-            verify(getMockVerification()).check(expected, LocaleVerifier.MessageKeys.AVAILABLE);
+            verify(getMockVerification()).report(expected, LocaleVerifier.MessageKeys.AVAILABLE);
         }
 
         @Test
@@ -186,7 +186,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().defaulting());
 
-            verify(getMockVerification()).check(expected, LocaleVerifier.MessageKeys.DEFAULTING);
+            verify(getMockVerification()).report(expected, LocaleVerifier.MessageKeys.DEFAULTING);
         }
 
         @Test
@@ -209,7 +209,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().country(country));
 
-            verify(getMockVerification()).check(eq(expected), eq(LocaleVerifier.MessageKeys.COUNTRY), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(LocaleVerifier.MessageKeys.COUNTRY), getArgsCaptor().capture());
 
             assertSame("Passes country for message formatting", country, getArgsCaptor().getValue());
         }
@@ -234,7 +234,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().language(language));
 
-            verify(getMockVerification()).check(eq(expected), eq(LocaleVerifier.MessageKeys.LANGUAGE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(LocaleVerifier.MessageKeys.LANGUAGE), getArgsCaptor().capture());
 
             assertSame("Passes language for message formatting", language, getArgsCaptor().getValue());
         }
@@ -263,7 +263,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().script(script));
 
-            verify(getMockVerification()).check(eq(expected), eq(LocaleVerifier.MessageKeys.SCRIPT), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(LocaleVerifier.MessageKeys.SCRIPT), getArgsCaptor().capture());
 
             assertSame("Passes script for message formatting", script, getArgsCaptor().getValue());
         }
@@ -288,7 +288,7 @@ public class LocaleVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().variant(variant));
 
-            verify(getMockVerification()).check(eq(expected), eq(LocaleVerifier.MessageKeys.VARIANT), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(LocaleVerifier.MessageKeys.VARIANT), getArgsCaptor().capture());
 
             assertSame("Passes variant for message formatting", variant, getArgsCaptor().getValue());
         }

--- a/src/test/java/io/skelp/verifier/type/MapVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/MapVerifierTest.java
@@ -176,7 +176,7 @@ public class MapVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAllKeys(keys));
 
-            verify(getMockVerification()).check(expected, MapVerifier.MessageKeys.CONTAIN_ALL_KEYS, (Object) keys);
+            verify(getMockVerification()).report(expected, MapVerifier.MessageKeys.CONTAIN_ALL_KEYS, (Object) keys);
         }
 
         @Test
@@ -229,7 +229,7 @@ public class MapVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAnyKey(keys));
 
-            verify(getMockVerification()).check(expected, MapVerifier.MessageKeys.CONTAIN_ANY_KEY, (Object) keys);
+            verify(getMockVerification()).report(expected, MapVerifier.MessageKeys.CONTAIN_ANY_KEY, (Object) keys);
         }
 
         @Test
@@ -259,7 +259,7 @@ public class MapVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containKey(key));
 
-            verify(getMockVerification()).check(eq(expected), eq(MapVerifier.MessageKeys.CONTAIN_KEY), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(MapVerifier.MessageKeys.CONTAIN_KEY), getArgsCaptor().capture());
 
             assertSame("Passes key for message formatting", key, getArgsCaptor().getValue());
         }

--- a/src/test/java/io/skelp/verifier/type/StringVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/StringVerifierTest.java
@@ -196,7 +196,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alpha());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.ALPHA);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.ALPHA);
         }
 
         @Test
@@ -244,7 +244,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alphaSpace());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.ALPHA_SPACE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.ALPHA_SPACE);
         }
 
         @Test
@@ -302,7 +302,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alphanumeric());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.ALPHANUMERIC);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.ALPHANUMERIC);
         }
 
         @Test
@@ -360,7 +360,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().alphanumericSpace());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.ALPHANUMERIC_SPACE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.ALPHANUMERIC_SPACE);
         }
 
         @Test
@@ -398,7 +398,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().asciiPrintable());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.ASCII_PRINTABLE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.ASCII_PRINTABLE);
         }
 
         @Test
@@ -426,7 +426,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().blank());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.BLANK);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.BLANK);
         }
 
         @Test
@@ -494,7 +494,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().contain(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.CONTAIN), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.CONTAIN), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -594,7 +594,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAll(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.CONTAIN_ALL, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.CONTAIN_ALL, (Object) others);
         }
 
         @Test
@@ -692,7 +692,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAllIgnoreCase(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.CONTAIN_ALL_IGNORE_CASE, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.CONTAIN_ALL_IGNORE_CASE, (Object) others);
         }
 
         @Test
@@ -770,7 +770,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAny(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.CONTAIN_ANY, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.CONTAIN_ANY, (Object) others);
         }
 
         @Test
@@ -848,7 +848,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAnyIgnoreCase(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.CONTAIN_ANY_IGNORE_CASE, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.CONTAIN_ANY_IGNORE_CASE, (Object) others);
         }
 
         @Test
@@ -936,7 +936,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containIgnoreCase(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.CONTAIN_IGNORE_CASE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.CONTAIN_IGNORE_CASE), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -966,7 +966,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().empty());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.EMPTY);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.EMPTY);
         }
 
         @Test
@@ -1039,7 +1039,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().endWith(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.END_WITH), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.END_WITH), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -1124,7 +1124,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().endWithAny(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.END_WITH_ANY, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.END_WITH_ANY, (Object) others);
         }
 
         @Test
@@ -1207,7 +1207,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().endWithAnyIgnoreCase(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.END_WITH_ANY_IGNORE_CASE, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.END_WITH_ANY_IGNORE_CASE, (Object) others);
         }
 
         @Test
@@ -1280,7 +1280,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().endWithIgnoreCase(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.END_WITH_IGNORE_CASE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.END_WITH_IGNORE_CASE), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -1362,7 +1362,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().equalToAnyIgnoreCase(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.EQUAL_TO_ANY_IGNORE_CASE, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.EQUAL_TO_ANY_IGNORE_CASE, (Object) others);
         }
 
         @Test
@@ -1432,7 +1432,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().equalToIgnoreCase(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.EQUAL_TO_IGNORE_CASE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.EQUAL_TO_IGNORE_CASE), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -1482,7 +1482,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lowerCase());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.LOWER_CASE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.LOWER_CASE);
         }
 
         @Test
@@ -1530,7 +1530,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().match(regex));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.MATCH), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.MATCH), getArgsCaptor().capture());
 
             assertSame("Passes regex for message formatting", regex, getArgsCaptor().getValue());
         }
@@ -1570,7 +1570,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().match(pattern));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.MATCH), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.MATCH), getArgsCaptor().capture());
 
             assertSame("Passes pattern for message formatting", pattern, getArgsCaptor().getValue());
         }
@@ -1620,7 +1620,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().numeric());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.NUMERIC);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.NUMERIC);
         }
 
         @Test
@@ -1668,7 +1668,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().numericSpace());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.NUMERIC_SPACE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.NUMERIC_SPACE);
         }
 
         @Test
@@ -1706,7 +1706,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sizeOf(size));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.SIZE_OF), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.SIZE_OF), getArgsCaptor().capture());
 
             assertSame("Passes size for message formatting", size, getArgsCaptor().getValue());
         }
@@ -1781,7 +1781,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().startWith(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.START_WITH), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.START_WITH), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -1866,7 +1866,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().startWithAny(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.START_WITH_ANY, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.START_WITH_ANY, (Object) others);
         }
 
         @Test
@@ -1949,7 +1949,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().startWithAnyIgnoreCase(others));
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.START_WITH_ANY_IGNORE_CASE, (Object) others);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.START_WITH_ANY_IGNORE_CASE, (Object) others);
         }
 
         @Test
@@ -2022,7 +2022,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().startWithIgnoreCase(other));
 
-            verify(getMockVerification()).check(eq(expected), eq(StringVerifier.MessageKeys.START_WITH_IGNORE_CASE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(StringVerifier.MessageKeys.START_WITH_IGNORE_CASE), getArgsCaptor().capture());
 
             assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
         }
@@ -2072,7 +2072,7 @@ public class StringVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().upperCase());
 
-            verify(getMockVerification()).check(expected, StringVerifier.MessageKeys.UPPER_CASE);
+            verify(getMockVerification()).report(expected, StringVerifier.MessageKeys.UPPER_CASE);
         }
 
         @Override

--- a/src/test/java/io/skelp/verifier/type/ThrowableVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/ThrowableVerifierTest.java
@@ -109,7 +109,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().causedBy(type));
 
-            verify(getMockVerification()).check(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
 
             assertSame("Passes type for message formatting", type, getArgsCaptor().getValue());
         }
@@ -155,7 +155,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().causedBy(cause));
 
-            verify(getMockVerification()).check(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
 
             assertSame("Passes cause for message formatting", cause, getArgsCaptor().getValue());
         }
@@ -201,7 +201,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().causedBy(cause, name));
 
-            verify(getMockVerification()).check(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ThrowableVerifier.MessageKeys.CAUSED_BY), getArgsCaptor().capture());
 
             assertSame("Passes name for message formatting", name, getArgsCaptor().getValue());
         }
@@ -226,7 +226,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().checked());
 
-            verify(getMockVerification()).check(expected, ThrowableVerifier.MessageKeys.CHECKED);
+            verify(getMockVerification()).report(expected, ThrowableVerifier.MessageKeys.CHECKED);
         }
 
         @Test
@@ -259,7 +259,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().message(message));
 
-            verify(getMockVerification()).check(eq(expected), eq(ThrowableVerifier.MessageKeys.MESSAGE), getArgsCaptor().capture());
+            verify(getMockVerification()).report(eq(expected), eq(ThrowableVerifier.MessageKeys.MESSAGE), getArgsCaptor().capture());
 
             assertSame("Passes message for message formatting", message, getArgsCaptor().getValue());
         }
@@ -284,7 +284,7 @@ public class ThrowableVerifierTest {
 
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().unchecked());
 
-            verify(getMockVerification()).check(expected, ThrowableVerifier.MessageKeys.UNCHECKED);
+            verify(getMockVerification()).report(expected, ThrowableVerifier.MessageKeys.UNCHECKED);
         }
 
         @Override

--- a/src/test/java/io/skelp/verifier/type/base/BaseCollectionVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseCollectionVerifierTestCase.java
@@ -79,7 +79,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().contain(element));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseCollectionVerifier.MessageKeys.CONTAIN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseCollectionVerifier.MessageKeys.CONTAIN), getArgsCaptor().capture());
 
         assertSame("Passes element for message formatting", element, getArgsCaptor().getValue());
     }
@@ -134,7 +134,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAll(elements));
 
-        verify(getMockVerification()).check(expected, BaseCollectionVerifier.MessageKeys.CONTAIN_ALL, (Object) elements);
+        verify(getMockVerification()).report(expected, BaseCollectionVerifier.MessageKeys.CONTAIN_ALL, (Object) elements);
     }
 
     @Test
@@ -187,7 +187,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().containAny(elements));
 
-        verify(getMockVerification()).check(expected, BaseCollectionVerifier.MessageKeys.CONTAIN_ANY, (Object) elements);
+        verify(getMockVerification()).report(expected, BaseCollectionVerifier.MessageKeys.CONTAIN_ANY, (Object) elements);
     }
 
     @Test
@@ -210,7 +210,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().empty());
 
-        verify(getMockVerification()).check(expected, BaseCollectionVerifier.MessageKeys.EMPTY);
+        verify(getMockVerification()).report(expected, BaseCollectionVerifier.MessageKeys.EMPTY);
     }
 
     @Test
@@ -248,7 +248,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sizeOf(size));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseCollectionVerifier.MessageKeys.SIZE_OF), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseCollectionVerifier.MessageKeys.SIZE_OF), getArgsCaptor().capture());
 
         assertSame("Passes size for message formatting", size, getArgsCaptor().getValue());
     }
@@ -298,7 +298,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAll(mockAssertion));
 
-        verify(getMockVerification()).check(expected, (String) null);
+        verify(getMockVerification()).report(expected, (String) null);
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
     }
 
@@ -347,8 +347,8 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertEquals("Matches elements correctly", expected, getCustomVerifier().thatAllInternal(mockAssertion));
 
-        verify(getMockVerification(), never()).check(anyBoolean(), any(MessageKey.class), anyVararg());
-        verify(getMockVerification(), never()).check(anyBoolean(), any(String.class), anyVararg());
+        verify(getMockVerification(), never()).report(anyBoolean(), any(MessageKey.class), anyVararg());
+        verify(getMockVerification(), never()).report(anyBoolean(), any(String.class), anyVararg());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
     }
 
@@ -397,7 +397,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAll(mockAssertion, message, args));
 
-        verify(getMockVerification()).check(eq(expected), eq(message), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(message), getArgsCaptor().capture());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());
@@ -448,7 +448,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAll(mockAssertion, key, args));
 
-        verify(getMockVerification()).check(eq(expected), eq(key), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(key), getArgsCaptor().capture());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());
@@ -499,7 +499,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAny(mockAssertion));
 
-        verify(getMockVerification()).check(expected, (String) null);
+        verify(getMockVerification()).report(expected, (String) null);
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
     }
 
@@ -548,8 +548,8 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertEquals("Matches elements correctly", expected, getCustomVerifier().thatAnyInternal(mockAssertion));
 
-        verify(getMockVerification(), never()).check(anyBoolean(), any(MessageKey.class), anyVararg());
-        verify(getMockVerification(), never()).check(anyBoolean(), any(String.class), anyVararg());
+        verify(getMockVerification(), never()).report(anyBoolean(), any(MessageKey.class), anyVararg());
+        verify(getMockVerification(), never()).report(anyBoolean(), any(String.class), anyVararg());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
     }
 
@@ -598,7 +598,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAny(mockAssertion, message, args));
 
-        verify(getMockVerification()).check(eq(expected), eq(message), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(message), getArgsCaptor().capture());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());
@@ -649,7 +649,7 @@ public abstract class BaseCollectionVerifierTestCase<E, T, V extends BaseCollect
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().thatAny(mockAssertion, key, args));
 
-        verify(getMockVerification()).check(eq(expected), eq(key), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(key), getArgsCaptor().capture());
         verify(mockAssertion, times(assertionCalls)).verify(any(getElementClass()));
 
         assertEquals("Passes args for message formatting", Arrays.asList(args), getArgsCaptor().getAllValues());

--- a/src/test/java/io/skelp/verifier/type/base/BaseComparableVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseComparableVerifierTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().between(start, end));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
 
         assertArrayEquals("Passes start and end for message formatting", new Object[]{start, end}, getArgsCaptor().getAllValues().toArray());
     }
@@ -153,7 +153,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().between(start, end, startName, endName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN), getArgsCaptor().capture());
 
         assertArrayEquals("Passes start and end names for message formatting", new Object[]{startName, endName}, getArgsCaptor().getAllValues().toArray());
     }
@@ -208,7 +208,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().betweenExclusive(start, end));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
 
         assertArrayEquals("Passes start and end for message formatting", new Object[]{start, end}, getArgsCaptor().getAllValues().toArray());
     }
@@ -263,7 +263,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().betweenExclusive(start, end, startName, endName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.BETWEEN_EXCLUSIVE), getArgsCaptor().capture());
 
         assertArrayEquals("Passes start and end names for message formatting", new Object[]{startName, endName}, getArgsCaptor().getAllValues().toArray());
     }
@@ -303,7 +303,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThan(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -343,7 +343,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThan(other, otherName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN), getArgsCaptor().capture());
 
         assertSame("Passes other name for message formatting", otherName, getArgsCaptor().getValue());
     }
@@ -383,7 +383,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThanOrEqualTo(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -423,7 +423,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().greaterThanOrEqualTo(other, otherName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.GREATER_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes other name for message formatting", otherName, getArgsCaptor().getValue());
     }
@@ -463,7 +463,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThan(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -503,7 +503,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThan(other, otherName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN), getArgsCaptor().capture());
 
         assertSame("Passes other name for message formatting", otherName, getArgsCaptor().getValue());
     }
@@ -543,7 +543,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThanOrEqualTo(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -583,7 +583,7 @@ public abstract class BaseComparableVerifierTestCase<T extends Comparable<? supe
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().lessThanOrEqualTo(other, otherName));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseComparableVerifier.MessageKeys.LESS_THAN_OR_EQUAL_TO), getArgsCaptor().capture());
 
         assertSame("Passes other name for message formatting", otherName, getArgsCaptor().getValue());
     }

--- a/src/test/java/io/skelp/verifier/type/base/BaseNumberVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseNumberVerifierTestCase.java
@@ -66,7 +66,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().even());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.EVEN);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.EVEN);
     }
 
     @Test
@@ -94,7 +94,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().negative());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.NEGATIVE);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.NEGATIVE);
     }
 
     @Test
@@ -122,7 +122,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().odd());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.ODD);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.ODD);
     }
 
     @Test
@@ -150,7 +150,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().one());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.ONE);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.ONE);
     }
 
     @Test
@@ -178,7 +178,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().positive());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.POSITIVE);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.POSITIVE);
     }
 
     @Test
@@ -206,7 +206,7 @@ public abstract class BaseNumberVerifierTestCase<T extends Number, V extends Bas
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().zero());
 
-        verify(getMockVerification()).check(expected, BaseNumberVerifier.MessageKeys.ZERO);
+        verify(getMockVerification()).report(expected, BaseNumberVerifier.MessageKeys.ZERO);
     }
 
     /**

--- a/src/test/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseSortableCollectionVerifierTestCase.java
@@ -86,7 +86,7 @@ public abstract class BaseSortableCollectionVerifierTestCase<E extends Comparabl
 
         verify(comparator, comparatorUseExpected ? atLeastOnce() : never()).compare(any(getElementClass()), any(getElementClass()));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseSortableCollectionVerifier.MessageKeys.SORTED_BY), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseSortableCollectionVerifier.MessageKeys.SORTED_BY), getArgsCaptor().capture());
 
         assertSame("Passes comparator for message formatting", comparator, getArgsCaptor().getValue());
     }
@@ -133,7 +133,7 @@ public abstract class BaseSortableCollectionVerifierTestCase<E extends Comparabl
 
         verify(comparator, comparatorUseExpected ? atLeastOnce() : never()).compare(any(getElementClass()), any(getElementClass()));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseSortableCollectionVerifier.MessageKeys.SORTED_BY), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseSortableCollectionVerifier.MessageKeys.SORTED_BY), getArgsCaptor().capture());
 
         assertSame("Passes name for message formatting", name, getArgsCaptor().getValue());
     }

--- a/src/test/java/io/skelp/verifier/type/base/BaseTimeVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseTimeVerifierTestCase.java
@@ -158,7 +158,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameDayAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_DAY_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_DAY_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -202,7 +202,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameEraAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_ERA_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_ERA_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -271,7 +271,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameHourAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_HOUR_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_HOUR_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -347,7 +347,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameMinuteAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_MINUTE_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_MINUTE_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -407,7 +407,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameMonthAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_MONTH_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_MONTH_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -491,7 +491,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameSecondAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_SECOND_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_SECOND_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -535,7 +535,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameTimeAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_TIME_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_TIME_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -595,7 +595,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameWeekAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_WEEK_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_WEEK_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }
@@ -647,7 +647,7 @@ public abstract class BaseTimeVerifierTestCase<T extends Comparable<? super T>, 
 
         assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().sameYearAs(other));
 
-        verify(getMockVerification()).check(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_YEAR_AS), getArgsCaptor().capture());
+        verify(getMockVerification()).report(eq(expected), eq(BaseTimeVerifier.MessageKeys.SAME_YEAR_AS), getArgsCaptor().capture());
 
         assertSame("Passes other for message formatting", other, getArgsCaptor().getValue());
     }

--- a/src/test/java/io/skelp/verifier/type/base/BaseTruthVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/type/base/BaseTruthVerifierTestCase.java
@@ -63,7 +63,7 @@ public abstract class BaseTruthVerifierTestCase<T, V extends BaseTruthVerifier<T
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().falsy());
         }
 
-        verify(getMockVerification(), times(values.length)).check(expected, BaseTruthVerifier.MessageKeys.FALSY);
+        verify(getMockVerification(), times(values.length)).report(expected, BaseTruthVerifier.MessageKeys.FALSY);
     }
 
     @Test
@@ -88,7 +88,7 @@ public abstract class BaseTruthVerifierTestCase<T, V extends BaseTruthVerifier<T
             assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().truthy());
         }
 
-        verify(getMockVerification(), times(values.length)).check(expected, BaseTruthVerifier.MessageKeys.TRUTHY);
+        verify(getMockVerification(), times(values.length)).report(expected, BaseTruthVerifier.MessageKeys.TRUTHY);
     }
 
     /**

--- a/src/test/java/io/skelp/verifier/verification/DefaultVerificationProviderTest.java
+++ b/src/test/java/io/skelp/verifier/verification/DefaultVerificationProviderTest.java
@@ -38,6 +38,9 @@ import io.skelp.verifier.message.locale.LocaleContext;
 import io.skelp.verifier.message.locale.LocaleContextProvider;
 import io.skelp.verifier.message.locale.TestLocaleContextProvider;
 import io.skelp.verifier.service.Weighted;
+import io.skelp.verifier.verification.report.ReportExecutor;
+import io.skelp.verifier.verification.report.ReportExecutorProvider;
+import io.skelp.verifier.verification.report.TestReportExecutorProvider;
 
 /**
  * <p>
@@ -57,6 +60,10 @@ public class DefaultVerificationProviderTest {
     private MessageSource mockMessageSource;
     @Mock
     private MessageSourceProvider mockMessageSourceProvider;
+    @Mock
+    private ReportExecutor mockReportExecutor;
+    @Mock
+    private ReportExecutorProvider mockReportExecutorProvider;
 
     private DefaultVerificationProvider provider;
 
@@ -64,9 +71,11 @@ public class DefaultVerificationProviderTest {
     public void setUp() {
         when(mockLocaleContextProvider.getLocaleContext()).thenReturn(mockLocaleContext);
         when(mockMessageSourceProvider.getMessageSource()).thenReturn(mockMessageSource);
+        when(mockReportExecutorProvider.getReportExecutor()).thenReturn(mockReportExecutor);
 
         TestLocaleContextProvider.setDelegate(mockLocaleContextProvider);
         TestMessageSourceProvider.setDelegate(mockMessageSourceProvider);
+        TestReportExecutorProvider.setDelegate(mockReportExecutorProvider);
 
         provider = new DefaultVerificationProvider();
     }
@@ -75,6 +84,7 @@ public class DefaultVerificationProviderTest {
     public void tearDown() {
         TestLocaleContextProvider.setDelegate(null);
         TestMessageSourceProvider.setDelegate(null);
+        TestReportExecutorProvider.setDelegate(null);
     }
 
     @Test
@@ -85,6 +95,7 @@ public class DefaultVerificationProviderTest {
         assertTrue("Returns instance of SimpleVerification", verification instanceof SimpleVerification);
         assertSame("Passed LocaleContext from provider", mockLocaleContext, verification.getLocaleContext());
         assertSame("Passed MessageSource from provider", mockMessageSource, verification.getMessageSource());
+        assertSame("Passed ReportExecutor from provider", mockReportExecutor, verification.getReportExecutor());
         assertEquals("Passed name", "foo", verification.getName());
         assertEquals("Passed value", Integer.valueOf(123), verification.getValue());
     }

--- a/src/test/java/io/skelp/verifier/verification/report/AbstractReportExecutorTestCase.java
+++ b/src/test/java/io/skelp/verifier/verification/report/AbstractReportExecutorTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Test case for {@link AbstractReportExecutor} implementation classes.
+ * </p>
+ *
+ * @param <T>
+ *         the type of the {@link AbstractReportExecutor} being tested
+ * @author Alasdair Mercer
+ */
+@RunWith(Theories.class)
+public abstract class AbstractReportExecutorTestCase<T extends AbstractReportExecutor> {
+
+    @DataPoints
+    public static final boolean[] DATA_POINTS = {true, false};
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private MessageHolder mockMessageHolder;
+    @Mock
+    private Reporter mockReporter1;
+    @Mock
+    private Reporter mockReporter2;
+    @Mock
+    private Reporter mockReporter3;
+    @Mock
+    private Verification<?> mockVerification;
+
+    private List<Reporter> reporters;
+
+    private T reportExecutor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        reporters = Arrays.asList(mockReporter1, mockReporter2, mockReporter3);
+
+        reportExecutor = createReportExecutor(reporters);
+    }
+
+    @Theory
+    public void testExecute(boolean result) {
+        when(mockReporter1.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+        when(mockReporter2.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+        when(mockReporter3.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+
+        reportExecutor.execute(mockVerification, result, mockMessageHolder);
+
+        verify(mockReporter1).report(mockVerification, result, mockMessageHolder);
+        verify(mockReporter2).report(mockVerification, result, mockMessageHolder);
+        verify(mockReporter3).report(mockVerification, result, mockMessageHolder);
+    }
+
+    @Theory
+    public void testExecuteWhenReporterBlocksNext(boolean result) {
+        when(mockReporter1.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+        when(mockReporter2.report(mockVerification, result, mockMessageHolder)).thenReturn(false);
+        when(mockReporter3.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+
+        reportExecutor.execute(mockVerification, result, mockMessageHolder);
+
+        verify(mockReporter1).report(mockVerification, result, mockMessageHolder);
+        verify(mockReporter2).report(mockVerification, result, mockMessageHolder);
+        verify(mockReporter3, never()).report(mockVerification, result, mockMessageHolder);
+    }
+
+    @Theory
+    public void testExecuteWhenReporterThrows(boolean result) {
+        thrown.expect(VerifierException.class);
+
+        when(mockReporter1.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+        when(mockReporter2.report(mockVerification, result, mockMessageHolder)).thenThrow(new VerifierException());
+        when(mockReporter3.report(mockVerification, result, mockMessageHolder)).thenReturn(true);
+
+        try {
+            reportExecutor.execute(mockVerification, result, mockMessageHolder);
+        } finally {
+            verify(mockReporter1).report(mockVerification, result, mockMessageHolder);
+            verify(mockReporter2).report(mockVerification, result, mockMessageHolder);
+            verify(mockReporter3, never()).report(mockVerification, result, mockMessageHolder);
+        }
+    }
+
+    @Test
+    public void testGetReporters() {
+        assertEquals("Has correct list of reporters", reporters, reportExecutor.getReporters());
+    }
+
+    /**
+     * <p>
+     * Creates an instance of the reporter executor test subject to be tested using the {@code reporters} provided.
+     * </p>
+     *
+     * @param reporters
+     *         the {@link Reporter Reporters} to be used
+     * @return The {@link AbstractReportExecutor} to be tested.F
+     */
+    protected abstract T createReportExecutor(List<Reporter> reporters);
+
+    /**
+     * <p>
+     * Returns the reporters being used to test the subject.
+     * </p>
+     *
+     * @return The {@code List} of {@link Reporter Reporters}.
+     */
+    protected List<Reporter> getReporters() {
+        return reporters;
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/AssertionReporterTest.java
+++ b/src/test/java/io/skelp/verifier/verification/report/AssertionReporterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.skelp.verifier.VerifierException;
+import io.skelp.verifier.service.Weighted;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Tests for the {@link AssertionReporter} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AssertionReporterTest {
+
+    private static final String TEST_MESSAGE = "i am expected";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private MessageHolder mockMessageHolder;
+    @Mock
+    private Verification<?> mockVerification;
+
+    private AssertionReporter reporter;
+
+    @Before
+    public void setUp() {
+        when(mockMessageHolder.getMessage(mockVerification)).thenReturn(TEST_MESSAGE);
+
+        reporter = new AssertionReporter();
+    }
+
+    @Test
+    public void testReportWhenResultIsFalse() {
+        testReportHelper(false, false, true);
+    }
+
+    @Test
+    public void testReportWhenResultIsFalseAndVerificationIsNegated() {
+        testReportHelper(true, false, false);
+    }
+
+    @Test
+    public void testReportWhenResultIsTrue() {
+        testReportHelper(false, true, false);
+    }
+
+    @Test
+    public void testReportWhenResultIsTrueAndVerificationIsNegated() {
+        testReportHelper(true, true, true);
+    }
+
+    private void testReportHelper(boolean negated, boolean result, boolean exceptionExpected) {
+        if (exceptionExpected) {
+            thrown.expect(VerifierException.class);
+            thrown.expectMessage(TEST_MESSAGE);
+        }
+
+        when(mockVerification.isNegated()).thenReturn(negated);
+
+        assertTrue("Never returns false", reporter.report(mockVerification, result, mockMessageHolder));
+    }
+
+    @Test
+    public void testGetWeight() {
+        assertEquals("Has default implementation weight", Weighted.DEFAULT_IMPLEMENTATION_WEIGHT, reporter.getWeight());
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/DefaultReportExecutorProviderTest.java
+++ b/src/test/java/io/skelp/verifier/verification/report/DefaultReportExecutorProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.skelp.verifier.service.Weighted;
+
+/**
+ * <p>
+ * Tests for the {@link DefaultReportExecutorProvider} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+public class DefaultReportExecutorProviderTest {
+
+    private static void assertReporters(ReportExecutor reportExecutor, Class<?>[] reporterClasses) {
+        List<Reporter> reporters = reportExecutor.getReporters();
+
+        assertNotNull("Has reporters", reporters);
+        assertEquals("Has correct number of reporters", reporterClasses.length, reporters.size());
+
+        for (int i = 0; i < reporterClasses.length; i++) {
+            Reporter reporter = reporters.get(i);
+            Class<?> reporterClass = reporterClasses[i];
+
+            assertNotNull("Reporter[" + i + "] is never null", reporter);
+            assertTrue("Reporter[" + i + "] is of expected type", reporterClass.isInstance(reporter));
+        }
+    }
+
+    private DefaultReportExecutorProvider provider;
+
+    @Before
+    public void setUp() {
+        provider = new DefaultReportExecutorProvider();
+    }
+
+    @Test
+    public void testGetReportExecutor() {
+        ReportExecutor reportExecutor = provider.getReportExecutor();
+
+        assertNotNull("Never returns null", reportExecutor);
+        assertTrue("Returns instance of SimpleReportExecutor", reportExecutor instanceof SimpleReportExecutor);
+
+        assertReporters(reportExecutor, new Class<?>[]{AssertionReporter.class});
+    }
+
+    @Test
+    public void testGetWeight() {
+        assertEquals("Has default implementation weight", Weighted.DEFAULT_IMPLEMENTATION_WEIGHT, provider.getWeight());
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/KeyMessageHolderTest.java
+++ b/src/test/java/io/skelp/verifier/verification/report/KeyMessageHolderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.skelp.verifier.message.MessageKey;
+import io.skelp.verifier.message.MessageSource;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Tests for the {@link KeyMessageHolder} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KeyMessageHolderTest {
+
+    @Mock
+    private MessageSource mockMessageSource;
+    @Mock
+    private Verification<?> mockVerification;
+
+    @Before
+    public void setUp() {
+        when(mockVerification.getMessageSource()).thenReturn(mockMessageSource);
+    }
+
+    @Test
+    public void testGetMessage() {
+        String expected = "i am expected";
+        MessageKey key = () -> "test";
+        Object[] args = new Object[]{"foo", "bar"};
+
+        when(mockMessageSource.getMessage(mockVerification, key, args)).thenReturn(expected);
+
+        KeyMessageHolder holder = new KeyMessageHolder(key, args);
+        assertEquals("Uses message source to return message", expected, holder.getMessage(mockVerification));
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/SimpleReportExecutorTest.java
+++ b/src/test/java/io/skelp/verifier/verification/report/SimpleReportExecutorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import java.util.List;
+
+/**
+ * <p>
+ * Tests for the {@link SimpleReportExecutor} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+public class SimpleReportExecutorTest extends AbstractReportExecutorTestCase<SimpleReportExecutor> {
+
+    @Override
+    protected SimpleReportExecutor createReportExecutor(List<Reporter> reporters) {
+        return new SimpleReportExecutor(reporters);
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/StringMessageHolderTest.java
+++ b/src/test/java/io/skelp/verifier/verification/report/StringMessageHolderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.skelp.verifier.message.MessageSource;
+import io.skelp.verifier.verification.Verification;
+
+/**
+ * <p>
+ * Tests for the {@link StringMessageHolder} class.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class StringMessageHolderTest {
+
+    @Mock
+    private MessageSource mockMessageSource;
+    @Mock
+    private Verification<?> mockVerification;
+
+    @Before
+    public void setUp() {
+        when(mockVerification.getMessageSource()).thenReturn(mockMessageSource);
+    }
+
+    @Test
+    public void testGetMessage() {
+        String expected = "i am expected";
+        String message = "test";
+        Object[] args = new Object[]{"foo", "bar"};
+
+        when(mockMessageSource.getMessage(mockVerification, message, args)).thenReturn(expected);
+
+        StringMessageHolder holder = new StringMessageHolder(message, args);
+        assertEquals("Uses message source to return message", expected, holder.getMessage(mockVerification));
+    }
+}

--- a/src/test/java/io/skelp/verifier/verification/report/TestReportExecutorProvider.java
+++ b/src/test/java/io/skelp/verifier/verification/report/TestReportExecutorProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.skelp.verifier.verification.report;
+
+/**
+ * <p>
+ * An implementation of {@link ReportExecutorProvider} that is intended to be used for test purposes only by allowing
+ * tests to register a delegate (normally a mock).
+ * </p>
+ * <p>
+ * Individual tests are also responsible for ensuring that the delegate is cleared in their tear down to avoid
+ * potentially affecting other unit tests.
+ * </p>
+ *
+ * @author Alasdair Mercer
+ */
+public final class TestReportExecutorProvider implements ReportExecutorProvider {
+
+    private static ReportExecutorProvider delegate;
+
+    /**
+     * <p>
+     * Returns the delegate for this {@link TestReportExecutorProvider}.
+     * </p>
+     *
+     * @return The delegate {@link ReportExecutorProvider} or {@literal null} if none has been specified.
+     */
+    public static ReportExecutorProvider getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * <p>
+     * Sets the delegate for this {@link TestReportExecutorProvider} to {@code delegate}.
+     * </p>
+     *
+     * @param delegate
+     *         the delegate {@link ReportExecutorProvider} to be set (may be {@literal null})
+     */
+    public static void setDelegate(ReportExecutorProvider delegate) {
+        TestReportExecutorProvider.delegate = delegate;
+    }
+
+    @Override
+    public ReportExecutor getReportExecutor() {
+        return delegate != null ? delegate.getReportExecutor() : null;
+    }
+
+    @Override
+    public int getWeight() {
+        return 0;
+    }
+}

--- a/src/test/resources/META-INF/services/io.skelp.verifier.verification.report.ReportExecutorProvider
+++ b/src/test/resources/META-INF/services/io.skelp.verifier.verification.report.ReportExecutorProvider
@@ -1,0 +1,2 @@
+io.skelp.verifier.verification.report.DefaultReportExecutorProvider
+io.skelp.verifier.verification.report.TestReportExecutorProvider


### PR DESCRIPTION
This is a second attempt PR as the first (#12) was accidentally merged into master and reverted (#13), so let's try again, but this time merging into develop.

---

In 0.1.0 the only thing that Verifier could do upon verification would be to assert that the verification passed and throw a `VerifierException` otherwise.

This PR changes this behaviour only slightly. By default, the above is still what happens, however, consumers of Verifier can now tap into the reporting process of the verification if needed and even prevent an error from being thrown if they so desired. The main intention here is to simply allow consumers to configure and customize Verifier as much as possible and this was a key step towards that. This would could allow consumers to even log verifications, if they wanted to, pass/fail.

Following on the back of #11, custom `Reporters` and even `ReportExecutor` are registered and loaded using Java's SPI.