### PR TITLE
Rename LocaleVerifier#defaulting to LocaleVerifier#defaulted

### DIFF
--- a/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
+++ b/src/main/java/io/skelp/verifier/type/LocaleVerifier.java
@@ -112,20 +112,21 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
      * Verifies that the value is the default {@code Locale}.
      * </p>
      * <pre>
-     * Verifier.verify((Locale) null).defaulting()            =&gt; FAIL
-     * Verifier.verify(Locale.getDefault()).defaulting()      =&gt; PASS
-     * Verifier.verify(new Locale("foo", "BAR")).defaulting() =&gt; FAIL
+     * Verifier.verify((Locale) null).defaulted()            =&gt; FAIL
+     * Verifier.verify(Locale.getDefault()).defaulted()      =&gt; PASS
+     * Verifier.verify(new Locale("foo", "BAR")).defaulted() =&gt; FAIL
      * </pre>
      *
      * @return A reference to this {@link LocaleVerifier} for chaining purposes.
      * @throws VerifierException
      *         If the verification fails while not negated or passes while negated.
+     * @since 0.2.0
      */
-    public LocaleVerifier defaulting() {
+    public LocaleVerifier defaulted() {
         final Locale value = verification().getValue();
         final boolean result = Locale.getDefault().equals(value);
 
-        verification().report(result, MessageKeys.DEFAULTING);
+        verification().report(result, MessageKeys.DEFAULTED);
 
         return this;
     }
@@ -230,7 +231,7 @@ public final class LocaleVerifier extends AbstractCustomVerifier<Locale, LocaleV
 
         AVAILABLE("io.skelp.verifier.type.LocaleVerifier.available"),
         COUNTRY("io.skelp.verifier.type.LocaleVerifier.country"),
-        DEFAULTING("io.skelp.verifier.type.LocaleVerifier.defaulting"),
+        DEFAULTED("io.skelp.verifier.type.LocaleVerifier.defaulted"),
         LANGUAGE("io.skelp.verifier.type.LocaleVerifier.language"),
         SCRIPT("io.skelp.verifier.type.LocaleVerifier.script"),
         VARIANT("io.skelp.verifier.type.LocaleVerifier.variant");

--- a/src/main/resources/Verifier.properties
+++ b/src/main/resources/Verifier.properties
@@ -103,7 +103,7 @@ io.skelp.verifier.type.ClassVerifier.primitiveWrapper=be a primitive wrapper
 
 io.skelp.verifier.type.LocaleVerifier.available=be available
 io.skelp.verifier.type.LocaleVerifier.country=be country ''{0}''
-io.skelp.verifier.type.LocaleVerifier.defaulting=be default
+io.skelp.verifier.type.LocaleVerifier.defaulted=be default
 io.skelp.verifier.type.LocaleVerifier.language=be language ''{0}''
 io.skelp.verifier.type.LocaleVerifier.script=be script ''{0}''
 io.skelp.verifier.type.LocaleVerifier.variant=be variant ''{0}''

--- a/src/test/java/io/skelp/verifier/type/LocaleVerifierTest.java
+++ b/src/test/java/io/skelp/verifier/type/LocaleVerifierTest.java
@@ -166,27 +166,27 @@ public class LocaleVerifierTest {
         }
 
         @Test
-        public void testDefaultingWithDefaultValue() {
-            testDefaultingHelper(Locale.ENGLISH, Locale.ENGLISH, true);
+        public void testDefaultedWithDefaultValue() {
+            testDefaultedHelper(Locale.ENGLISH, Locale.ENGLISH, true);
         }
 
         @Test
-        public void testDefaultingWithNonDefaultValue() {
-            testDefaultingHelper(Locale.GERMAN, Locale.ENGLISH, false);
+        public void testDefaultedWithNonDefaultValue() {
+            testDefaultedHelper(Locale.GERMAN, Locale.ENGLISH, false);
         }
 
         @Test
-        public void testDefaultingWithNullValue() {
-            testDefaultingHelper(null, Locale.ENGLISH, false);
+        public void testDefaultedWithNullValue() {
+            testDefaultedHelper(null, Locale.ENGLISH, false);
         }
 
-        private void testDefaultingHelper(Locale value, Locale defaultLocale, boolean expected) {
+        private void testDefaultedHelper(Locale value, Locale defaultLocale, boolean expected) {
             setValue(value);
             Locale.setDefault(defaultLocale);
 
-            assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().defaulting());
+            assertSame("Chains reference", getCustomVerifier(), getCustomVerifier().defaulted());
 
-            verify(getMockVerification()).report(expected, LocaleVerifier.MessageKeys.DEFAULTING);
+            verify(getMockVerification()).report(expected, LocaleVerifier.MessageKeys.DEFAULTED);
         }
 
         @Test
@@ -311,7 +311,7 @@ public class LocaleVerifierTest {
             Map<String, String> messageKeys = new HashMap<>();
             messageKeys.put("AVAILABLE", "io.skelp.verifier.type.LocaleVerifier.available");
             messageKeys.put("COUNTRY", "io.skelp.verifier.type.LocaleVerifier.country");
-            messageKeys.put("DEFAULTING", "io.skelp.verifier.type.LocaleVerifier.defaulting");
+            messageKeys.put("DEFAULTED", "io.skelp.verifier.type.LocaleVerifier.defaulted");
             messageKeys.put("LANGUAGE", "io.skelp.verifier.type.LocaleVerifier.language");
             messageKeys.put("SCRIPT", "io.skelp.verifier.type.LocaleVerifier.script");
             messageKeys.put("VARIANT", "io.skelp.verifier.type.LocaleVerifier.variant");


### PR DESCRIPTION
This PR renames the `LocaleVerifier#defaulting` method to `LocaleVerifier#defaulted` so that it's more in line with other methods (e.g. `CustomVerifier#nulled`).