### PR TITLE
Add CustomVerifier#and & CustomVerifier#andComparable methods to allow even more fluid chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ public class LoginForm implements Form {
     public void handle(Map<String, String> data) {
         Verifier.verify(data)
             .containAllKeys("username", "password");
-        Verifier.verify(data.get("username"), "username")
-            .not().blank();
-        Verifier.verify(data.get("password"), "password")
-            .not().empty()
-            .alphanumeric();
+            .and(data.get("username"), "username")
+                .not().blank();
+            .and(data.get("password"), "password")
+                .not().empty()
+                .alphanumeric();
 
         userService.login(data);
     }
@@ -81,12 +81,12 @@ public class RegistrationForm implements Form {
     public void handle(Map<String, String> data) {
         Verifier.verify(data)
             .containAllKeys("username", "password");
-        Verifier.verify(data.get("username"), "username")
-            .not().blank()
-            .that((value) -> userService.isAvailable(value));
-        Verifier.verify(data.get("password"), "password", PasswordVerifier.class)
-            .not().nulled()
-            .strong();
+            .and(data.get("username"), "username")
+                .not().blank()
+                .that((value) -> userService.isAvailable(value));
+            .and(data.get("password"), "password", PasswordVerifier.class)
+                .not().nulled()
+                .strong();
 
         userService.register(data);
     }

--- a/src/main/java/io/skelp/verifier/AbstractCustomVerifier.java
+++ b/src/main/java/io/skelp/verifier/AbstractCustomVerifier.java
@@ -21,11 +21,39 @@
  */
 package io.skelp.verifier;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
 import io.skelp.verifier.message.MessageKey;
+import io.skelp.verifier.service.Services;
+import io.skelp.verifier.type.ArrayVerifier;
+import io.skelp.verifier.type.BigDecimalVerifier;
+import io.skelp.verifier.type.BigIntegerVerifier;
+import io.skelp.verifier.type.BooleanVerifier;
+import io.skelp.verifier.type.ByteVerifier;
+import io.skelp.verifier.type.CalendarVerifier;
+import io.skelp.verifier.type.CharacterVerifier;
+import io.skelp.verifier.type.ClassVerifier;
+import io.skelp.verifier.type.CollectionVerifier;
+import io.skelp.verifier.type.ComparableVerifier;
+import io.skelp.verifier.type.DateVerifier;
+import io.skelp.verifier.type.DoubleVerifier;
+import io.skelp.verifier.type.FloatVerifier;
+import io.skelp.verifier.type.IntegerVerifier;
+import io.skelp.verifier.type.LocaleVerifier;
+import io.skelp.verifier.type.LongVerifier;
+import io.skelp.verifier.type.MapVerifier;
+import io.skelp.verifier.type.ObjectVerifier;
+import io.skelp.verifier.type.ShortVerifier;
+import io.skelp.verifier.type.StringVerifier;
+import io.skelp.verifier.type.ThrowableVerifier;
 import io.skelp.verifier.verification.Verification;
 
 /**
@@ -166,6 +194,222 @@ public abstract class AbstractCustomVerifier<T, V extends AbstractCustomVerifier
      */
     public AbstractCustomVerifier(final Verification<T> verification) {
         this.verification = verification;
+    }
+
+    @Override
+    public <E> ArrayVerifier<E> and(final E[] value) {
+        return and(value, null);
+    }
+
+    @Override
+    public <E> ArrayVerifier<E> and(final E[] value, final Object name) {
+        return new ArrayVerifier<>(verification.copy(value, name));
+    }
+
+    @Override
+    public BigDecimalVerifier and(final BigDecimal value) {
+        return and(value, null);
+    }
+
+    @Override
+    public BigDecimalVerifier and(final BigDecimal value, final Object name) {
+        return new BigDecimalVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public BigIntegerVerifier and(final BigInteger value) {
+        return and(value, null);
+    }
+
+    @Override
+    public BigIntegerVerifier and(final BigInteger value, final Object name) {
+        return new BigIntegerVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public BooleanVerifier and(final Boolean value) {
+        return and(value, null);
+    }
+
+    @Override
+    public BooleanVerifier and(final Boolean value, final Object name) {
+        return new BooleanVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public ByteVerifier and(final Byte value) {
+        return and(value, null);
+    }
+
+    @Override
+    public ByteVerifier and(final Byte value, final Object name) {
+        return new ByteVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public CalendarVerifier and(final Calendar value) {
+        return and(value, null);
+    }
+
+    @Override
+    public CalendarVerifier and(final Calendar value, final Object name) {
+        return new CalendarVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public CharacterVerifier and(final Character value) {
+        return and(value, null);
+    }
+
+    @Override
+    public CharacterVerifier and(final Character value, final Object name) {
+        return new CharacterVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public ClassVerifier and(final Class value) {
+        return and(value, null);
+    }
+
+    @Override
+    public ClassVerifier and(final Class value, final Object name) {
+        return new ClassVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public <E> CollectionVerifier<E> and(final Collection<E> value) {
+        return and(value, null);
+    }
+
+    @Override
+    public <E> CollectionVerifier<E> and(final Collection<E> value, final Object name) {
+        return new CollectionVerifier<>(verification.copy(value, name));
+    }
+
+    @Override
+    public DateVerifier and(final Date value) {
+        return and(value, null);
+    }
+
+    @Override
+    public DateVerifier and(final Date value, final Object name) {
+        return new DateVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public DoubleVerifier and(final Double value) {
+        return and(value, null);
+    }
+
+    @Override
+    public DoubleVerifier and(final Double value, final Object name) {
+        return new DoubleVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public FloatVerifier and(final Float value) {
+        return and(value, null);
+    }
+
+    @Override
+    public FloatVerifier and(final Float value, final Object name) {
+        return new FloatVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public IntegerVerifier and(final Integer value) {
+        return and(value, null);
+    }
+
+    @Override
+    public IntegerVerifier and(final Integer value, final Object name) {
+        return new IntegerVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public LocaleVerifier and(final Locale value) {
+        return and(value, null);
+    }
+
+    @Override
+    public LocaleVerifier and(final Locale value, final Object name) {
+        return new LocaleVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public LongVerifier and(final Long value) {
+        return and(value, null);
+    }
+
+    @Override
+    public LongVerifier and(final Long value, final Object name) {
+        return new LongVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public <K, U> MapVerifier<K, U> and(final Map<K, U> value) {
+        return and(value, null);
+    }
+
+    @Override
+    public <K, U> MapVerifier<K, U> and(final Map<K, U> value, final Object name) {
+        return new MapVerifier<>(verification.copy(value, name));
+    }
+
+    @Override
+    public ObjectVerifier and(final Object value) {
+        return and(value, null);
+    }
+
+    @Override
+    public ObjectVerifier and(final Object value, final Object name) {
+        return new ObjectVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public ShortVerifier and(final Short value) {
+        return and(value, null);
+    }
+
+    @Override
+    public ShortVerifier and(final Short value, final Object name) {
+        return new ShortVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public StringVerifier and(final String value) {
+        return and(value, null);
+    }
+
+    @Override
+    public StringVerifier and(final String value, final Object name) {
+        return new StringVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public ThrowableVerifier and(final Throwable value) {
+        return and(value, null);
+    }
+
+    @Override
+    public ThrowableVerifier and(final Throwable value, final Object name) {
+        return new ThrowableVerifier(verification.copy(value, name));
+    }
+
+    @Override
+    public <U, C extends CustomVerifier<U, C>> C and(final U value, final Object name, final Class<C> cls) {
+        final Verification<U> copy = verification.copy(value, name);
+        return Services.findFirstNonNullForWeightedService(CustomVerifierProvider.class, provider -> provider.getCustomVerifier(cls, copy));
+    }
+
+    @Override
+    public <C extends Comparable<? super C>> ComparableVerifier<C> andComparable(final C value) {
+        return andComparable(value, null);
+    }
+
+    @Override
+    public <C extends Comparable<? super C>> ComparableVerifier<C> andComparable(final C value, final Object name) {
+        return new ComparableVerifier<>(verification.copy(value, name));
     }
 
     /**

--- a/src/main/java/io/skelp/verifier/CustomVerifier.java
+++ b/src/main/java/io/skelp/verifier/CustomVerifier.java
@@ -21,7 +21,36 @@
  */
 package io.skelp.verifier;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+
 import io.skelp.verifier.message.MessageKey;
+import io.skelp.verifier.type.ArrayVerifier;
+import io.skelp.verifier.type.BigDecimalVerifier;
+import io.skelp.verifier.type.BigIntegerVerifier;
+import io.skelp.verifier.type.BooleanVerifier;
+import io.skelp.verifier.type.ByteVerifier;
+import io.skelp.verifier.type.CalendarVerifier;
+import io.skelp.verifier.type.CharacterVerifier;
+import io.skelp.verifier.type.ClassVerifier;
+import io.skelp.verifier.type.CollectionVerifier;
+import io.skelp.verifier.type.ComparableVerifier;
+import io.skelp.verifier.type.DateVerifier;
+import io.skelp.verifier.type.DoubleVerifier;
+import io.skelp.verifier.type.FloatVerifier;
+import io.skelp.verifier.type.IntegerVerifier;
+import io.skelp.verifier.type.LocaleVerifier;
+import io.skelp.verifier.type.LongVerifier;
+import io.skelp.verifier.type.MapVerifier;
+import io.skelp.verifier.type.ObjectVerifier;
+import io.skelp.verifier.type.ShortVerifier;
+import io.skelp.verifier.type.StringVerifier;
+import io.skelp.verifier.type.ThrowableVerifier;
 import io.skelp.verifier.verification.Verification;
 
 /**
@@ -37,6 +66,999 @@ import io.skelp.verifier.verification.Verification;
  * @author Alasdair Mercer
  */
 public interface CustomVerifier<T, V extends CustomVerifier<T, V>> {
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as an array using an {@link ArrayVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the array to be verified (may be {@literal null})
+     * @param <E>
+     *         the type of the elements contained within {@code value}
+     * @return An {@link ArrayVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ArrayVerifier}.
+     * @see #and(Object[], Object)
+     * @see ArrayVerifier
+     * @since 0.2.0
+     */
+    <E> ArrayVerifier<E> and(E[] value);
+
+    /**
+     * <p>
+     * Starts new a chain for verifying the specified {@code value} as an array using an {@link ArrayVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the array to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @param <E>
+     *         the type of the elements contained within {@code value}
+     * @return An {@link ArrayVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ArrayVerifier}.
+     * @see #and(Object[])
+     * @see ArrayVerifier
+     * @since 0.2.0
+     */
+    <E> ArrayVerifier<E> and(E[] value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a big decimal using a {@link BigDecimalVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code BigDecimal} to be verified (may be {@literal null})
+     * @return A {@link BigDecimalVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BigDecimalVerifier}.
+     * @see #and(BigDecimal, Object)
+     * @see BigDecimalVerifier
+     * @since 0.2.0
+     */
+    BigDecimalVerifier and(BigDecimal value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a big decimal using a {@link BigDecimalVerifier}
+     * while allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException}
+     * message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code BigDecimal} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link BigDecimalVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BigDecimalVerifier}.
+     * @see #and(BigDecimal)
+     * @see BigDecimalVerifier
+     * @since 0.2.0
+     */
+    BigDecimalVerifier and(BigDecimal value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a big integer using a {@link BigIntegerVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code BigInteger} to be verified (may be {@literal null})
+     * @return A {@link BigIntegerVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BigIntegerVerifier}.
+     * @see #and(BigInteger, Object)
+     * @see BigIntegerVerifier
+     * @since 0.2.0
+     */
+    BigIntegerVerifier and(BigInteger value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a big integer using a {@link BigIntegerVerifier}
+     * while allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException}
+     * message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code BigInteger} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link BigIntegerVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BigIntegerVerifier}.
+     * @see #and(BigInteger)
+     * @see BigIntegerVerifier
+     * @since 0.2.0
+     */
+    BigIntegerVerifier and(BigInteger value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a boolean using a {@link BooleanVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Boolean} to be verified (may be {@literal null})
+     * @return A {@link BooleanVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BooleanVerifier}.
+     * @see #and(Boolean, Object)
+     * @see BooleanVerifier
+     * @since 0.2.0
+     */
+    BooleanVerifier and(Boolean value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a boolean using a {@link BooleanVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Boolean} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link BooleanVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link BooleanVerifier}.
+     * @see #and(Boolean)
+     * @see BooleanVerifier
+     * @since 0.2.0
+     */
+    BooleanVerifier and(Boolean value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a byte using a {@link ByteVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Byte} to be verified (may be {@literal null})
+     * @return A {@link ByteVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ByteVerifier}.
+     * @see #and(Byte, Object)
+     * @see ByteVerifier
+     * @since 0.2.0
+     */
+    ByteVerifier and(Byte value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a byte using a {@link ByteVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Byte} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link ByteVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ByteVerifier}.
+     * @see #and(Byte)
+     * @see ByteVerifier
+     * @since 0.2.0
+     */
+    ByteVerifier and(Byte value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a calendar using a {@link CalendarVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Calendar} to be verified (may be {@literal null})
+     * @return A {@link CalendarVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CalendarVerifier}.
+     * @see #and(Calendar, Object)
+     * @see CalendarVerifier
+     * @since 0.2.0
+     */
+    CalendarVerifier and(Calendar value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a calendar using a {@link CalendarVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Calendar} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link CalendarVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CalendarVerifier}.
+     * @see #and(Calendar)
+     * @see CalendarVerifier
+     * @since 0.2.0
+     */
+    CalendarVerifier and(Calendar value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a character using a {@link CharacterVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Character} to be verified (may be {@literal null})
+     * @return A {@link CharacterVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CharacterVerifier}.
+     * @see #and(Character, Object)
+     * @see CharacterVerifier
+     * @since 0.2.0
+     */
+    CharacterVerifier and(Character value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a character using a {@link CharacterVerifier}
+     * while allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException}
+     * message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Character} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link CharacterVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CharacterVerifier}.
+     * @see #and(Character)
+     * @see CharacterVerifier
+     * @since 0.2.0
+     */
+    CharacterVerifier and(Character value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a class using a {@link ClassVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Class} to be verified (may be {@literal null})
+     * @return A {@link ClassVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ClassVerifier}.
+     * @see #and(Class, Object)
+     * @see ClassVerifier
+     * @since 0.2.0
+     */
+    ClassVerifier and(Class value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a class using a {@link ClassVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Class} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link ClassVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ClassVerifier}.
+     * @see #and(Class)
+     * @see ClassVerifier
+     * @since 0.2.0
+     */
+    ClassVerifier and(Class value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a collection using a {@link CollectionVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Collection} to be verified (may be {@literal null})
+     * @param <E>
+     *         the type of the elements contained within {@code value}
+     * @return A {@link CollectionVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CollectionVerifier}.
+     * @see #and(Collection, Object)
+     * @see CollectionVerifier
+     * @since 0.2.0
+     */
+    <E> CollectionVerifier<E> and(Collection<E> value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a collection using a {@link CollectionVerifier}
+     * while allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException}
+     * message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Collection} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @param <E>
+     *         the type of the elements contained within {@code value}
+     * @return A {@link CollectionVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CollectionVerifier}.
+     * @see #and(Collection)
+     * @see CollectionVerifier
+     * @since 0.2.0
+     */
+    <E> CollectionVerifier<E> and(Collection<E> value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a date using a {@link DateVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Date} to be verified (may be {@literal null})
+     * @return A {@link DateVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link DateVerifier}.
+     * @see #and(Date, Object)
+     * @see DateVerifier
+     * @since 0.2.0
+     */
+    DateVerifier and(Date value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a date using a {@link DateVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Date} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link DateVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link DateVerifier}.
+     * @see #and(Date)
+     * @see DateVerifier
+     * @since 0.2.0
+     */
+    DateVerifier and(Date value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a double using a {@link DoubleVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Double} to be verified (may be {@literal null})
+     * @return A {@link DoubleVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link DoubleVerifier}.
+     * @see #and(Double, Object)
+     * @see DoubleVerifier
+     * @since 0.2.0
+     */
+    DoubleVerifier and(Double value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a double using a {@link DoubleVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Double} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link DoubleVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link DoubleVerifier}.
+     * @see #and(Double)
+     * @see DoubleVerifier
+     * @since 0.2.0
+     */
+    DoubleVerifier and(Double value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a float using a {@link FloatVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Float} to be verified (may be {@literal null})
+     * @return A {@link FloatVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link FloatVerifier}.
+     * @see #and(Float, Object)
+     * @see FloatVerifier
+     * @since 0.2.0
+     */
+    FloatVerifier and(Float value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a float using a {@link FloatVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Float} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link FloatVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link FloatVerifier}.
+     * @see #and(Float)
+     * @see FloatVerifier
+     * @since 0.2.0
+     */
+    FloatVerifier and(Float value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as an integer using an {@link IntegerVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Integer} to be verified (may be {@literal null})
+     * @return An {@link IntegerVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link IntegerVerifier}.
+     * @see #and(Integer, Object)
+     * @see IntegerVerifier
+     * @since 0.2.0
+     */
+    IntegerVerifier and(Integer value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as an integer using an {@link IntegerVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Integer} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return An {@link IntegerVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link IntegerVerifier}.
+     * @see #and(Integer)
+     * @see IntegerVerifier
+     * @since 0.2.0
+     */
+    IntegerVerifier and(Integer value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a locale using a {@link LocaleVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Locale} to be verified (may be {@literal null})
+     * @return A {@link LocaleVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link LocaleVerifier}.
+     * @see #and(Locale, Object)
+     * @see LocaleVerifier
+     * @since 0.2.0
+     */
+    LocaleVerifier and(Locale value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a locale using a {@link LocaleVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Locale} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link LocaleVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link LocaleVerifier}.
+     * @see #and(Locale)
+     * @see LocaleVerifier
+     * @since 0.2.0
+     */
+    LocaleVerifier and(Locale value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a long using a {@link LongVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Long} to be verified (may be {@literal null})
+     * @return A {@link LongVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link LongVerifier}.
+     * @see #and(Long, Object)
+     * @see LongVerifier
+     * @since 0.2.0
+     */
+    LongVerifier and(Long value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a long using a {@link LongVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Long} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link LongVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link LongVerifier}.
+     * @see #and(Long)
+     * @see LongVerifier
+     * @since 0.2.0
+     */
+    LongVerifier and(Long value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a map using a {@link MapVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Map} to be verified (may be {@literal null})
+     * @param <K>
+     *         the type of the keys contained within {@code value}
+     * @param <U>
+     *         the type of the values contained within {@code value}
+     * @return A {@link MapVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link MapVerifier}.
+     * @see #and(Map, Object)
+     * @see MapVerifier
+     * @since 0.2.0
+     */
+    <K, U> MapVerifier<K, U> and(Map<K, U> value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a map using a {@link MapVerifier} while allowing
+     * {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message in the
+     * event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Map} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @param <K>
+     *         the type of the keys contained within {@code value}
+     * @param <U>
+     *         the type of the values contained within {@code value}
+     * @return A {@link MapVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link MapVerifier}.
+     * @see #and(Map)
+     * @see MapVerifier
+     * @since 0.2.0
+     */
+    <K, U> MapVerifier<K, U> and(Map<K, U> value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as an object using an {@link ObjectVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     * <p>
+     * For a lot of built-in data types other, more specific, {@code verify} methods may also exist which perhaps
+     * provide other useful verification methods. However, this method is useful for cases when one doesn't exist and
+     * for custom objects, possibly domain-specific.
+     * </p>
+     *
+     * @param value
+     *         the {@code Object} to be verified (may be {@literal null})
+     * @return An {@link ObjectVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ObjectVerifier}.
+     * @see #and(Object, Object)
+     * @see ObjectVerifier
+     * @since 0.2.0
+     */
+    ObjectVerifier and(Object value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as an object using an {@link ObjectVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     * <p>
+     * For a lot of built-in data types other, more specific, {@code verify} methods may also exist which perhaps
+     * provide other useful verification methods. However, this method is useful for cases when one doesn't exist and
+     * for custom objects, possibly domain-specific.
+     * </p>
+     *
+     * @param value
+     *         the {@code Object} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link ObjectVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ObjectVerifier}.
+     * @see #and(Object)
+     * @see ObjectVerifier
+     * @since 0.2.0
+     */
+    ObjectVerifier and(Object value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a short using a {@link ShortVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Short} to be verified (may be {@literal null})
+     * @return A {@link ShortVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ShortVerifier}.
+     * @see #and(Short, Object)
+     * @see ShortVerifier
+     * @since 0.2.0
+     */
+    ShortVerifier and(Short value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a short using a {@link ShortVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Short} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link ShortVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ShortVerifier}.
+     * @see #and(Short)
+     * @see ShortVerifier
+     * @since 0.2.0
+     */
+    ShortVerifier and(Short value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a string using a {@link StringVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code String} to be verified (may be {@literal null})
+     * @return A {@link StringVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link StringVerifier}.
+     * @see #and(String, Object)
+     * @see StringVerifier
+     * @since 0.2.0
+     */
+    StringVerifier and(String value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a string using a {@link StringVerifier} while
+     * allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException} message
+     * in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code String} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link StringVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link StringVerifier}.
+     * @see #and(String)
+     * @see StringVerifier
+     * @since 0.2.0
+     */
+    StringVerifier and(String value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a throwable using a {@link ThrowableVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Throwable} to be verified (may be {@literal null})
+     * @return A {@link ThrowableVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ThrowableVerifier}.
+     * @see #and(Throwable, Object)
+     * @see ThrowableVerifier
+     * @since 0.2.0
+     */
+    ThrowableVerifier and(Throwable value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a throwable using a {@link ThrowableVerifier}
+     * while allowing {@code value} to be given an optional friendlier {@code name} for the {@link VerifierException}
+     * message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the {@code Throwable} to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @return A {@link ThrowableVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ThrowableVerifier}.
+     * @see #and(Throwable)
+     * @see ThrowableVerifier
+     * @since 0.2.0
+     */
+    ThrowableVerifier and(Throwable value, Object name);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} of a type that matches the {@link CustomVerifier}
+     * {@code cls} provided, which will be instantiated and used while allowing {@code value} to be given an optional
+     * friendlier {@code name} for the {@link VerifierException} message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     *
+     * @param value
+     *         the value to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @param cls
+     *         the type of {@link CustomVerifier} to be instantiated and used to verify {@code value}
+     * @param <U>
+     *         the type of {@code value}
+     * @param <C>
+     *         the type of {@code cls} for chaining purposes
+     * @return An instance of {@code cls} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link CustomVerifier}.
+     * @since 0.2.0
+     */
+    <U, C extends CustomVerifier<U, C>> C and(U value, Object name, Class<C> cls);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a comparable object using a
+     * {@link ComparableVerifier}.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     * <p>
+     * For a lot of built-in {@code Comparable} data types other, more specific, {@code verify} methods may also exist
+     * which perhaps provide other useful verification methods. However, this method is useful for cases when one
+     * doesn't exist and for custom objects, possibly domain-specific.
+     * </p>
+     *
+     * @param value
+     *         the {@code Comparable} object to be verified (may be {@literal null})
+     * @param <C>
+     *         the {@code Comparable} type of {@code value}
+     * @return A {@link ComparableVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ComparableVerifier}.
+     * @see #andComparable(Comparable, Object)
+     * @see ComparableVerifier
+     * @since 0.2.0
+     */
+    <C extends Comparable<? super C>> ComparableVerifier<C> andComparable(C value);
+
+    /**
+     * <p>
+     * Starts a new chain for verifying the specified {@code value} as a comparable object using a
+     * {@link ComparableVerifier} while allowing {@code value} to be given an optional friendlier {@code name} for the
+     * {@link VerifierException} message in the event that one is thrown.
+     * </p>
+     * <p>
+     * If {@code value} fails any subsequent verifications within this chain a {@link VerifierException} will be thrown
+     * immediately by the method for the offending verification.
+     * </p>
+     * <p>
+     * For a lot of built-in {@code Comparable} data types other, more specific, {@code verify} methods may also exist
+     * which perhaps provide other useful verification methods. However, this method is useful for cases when one
+     * doesn't exist and for custom objects, possibly domain-specific.
+     * </p>
+     *
+     * @param value
+     *         the {@code Comparable} object to be verified (may be {@literal null})
+     * @param name
+     *         the optional name used to represent {@code value} (may be {@literal null})
+     * @param <C>
+     *         the {@code Comparable} type of {@code value}
+     * @return A {@link ComparableVerifier} to be used to verify {@code value}.
+     * @throws VerifierException
+     *         If a problem occurs while setting up the {@link ComparableVerifier}.
+     * @see #andComparable(Comparable)
+     * @see ComparableVerifier
+     * @since 0.2.0
+     */
+    <C extends Comparable<? super C>> ComparableVerifier<C> andComparable(C value, Object name);
 
     /**
      * <p>

--- a/src/main/java/io/skelp/verifier/verification/SimpleVerification.java
+++ b/src/main/java/io/skelp/verifier/verification/SimpleVerification.java
@@ -84,6 +84,11 @@ public final class SimpleVerification<T> implements Verification<T> {
     }
 
     @Override
+    public <V> Verification<V> copy(final V value, final Object name) {
+        return new SimpleVerification<>(localeContext, messageSource, formatterProvider, reportExecutor, value, name);
+    }
+
+    @Override
     public Formatter getFormatter(final Object obj) {
         return formatterProvider.getFormatter(obj);
     }

--- a/src/main/java/io/skelp/verifier/verification/Verification.java
+++ b/src/main/java/io/skelp/verifier/verification/Verification.java
@@ -53,6 +53,25 @@ public interface Verification<T> {
 
     /**
      * <p>
+     * Creates a copy of this {@link Verification} but using the {@code value} and optional {@code name} provided.
+     * </p>
+     * <p>
+     * The current negated state of this {@link Verification} is <b>not</b> copied.
+     * </p>
+     *
+     * @param value
+     *         the new value being verified
+     * @param name
+     *         the new optional name used to represent {@code value}
+     * @param <V>
+     *         the type of the new {@code value} being verified
+     * @return A copy for {@code value} and {@code name}.
+     * @since 0.2.0
+     */
+    <V> Verification<V> copy(V value, Object name);
+
+    /**
+     * <p>
      * Returns a formatter that can be used to format the specified object so that it is more human-friendly.
      * </p>
      * <p>

--- a/src/test/java/io/skelp/verifier/AbstractCustomVerifierTestCase.java
+++ b/src/test/java/io/skelp/verifier/AbstractCustomVerifierTestCase.java
@@ -24,13 +24,44 @@ package io.skelp.verifier;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import io.skelp.verifier.message.MessageKey;
+import io.skelp.verifier.type.ArrayVerifier;
+import io.skelp.verifier.type.BigDecimalVerifier;
+import io.skelp.verifier.type.BigIntegerVerifier;
+import io.skelp.verifier.type.BooleanVerifier;
+import io.skelp.verifier.type.ByteVerifier;
+import io.skelp.verifier.type.CalendarVerifier;
+import io.skelp.verifier.type.CharacterVerifier;
+import io.skelp.verifier.type.ClassVerifier;
+import io.skelp.verifier.type.CollectionVerifier;
+import io.skelp.verifier.type.ComparableVerifier;
+import io.skelp.verifier.type.DateVerifier;
+import io.skelp.verifier.type.DoubleVerifier;
+import io.skelp.verifier.type.FloatVerifier;
+import io.skelp.verifier.type.IntegerVerifier;
+import io.skelp.verifier.type.LocaleVerifier;
+import io.skelp.verifier.type.LongVerifier;
+import io.skelp.verifier.type.MapVerifier;
+import io.skelp.verifier.type.ObjectVerifier;
+import io.skelp.verifier.type.ShortVerifier;
+import io.skelp.verifier.type.StringVerifier;
+import io.skelp.verifier.type.ThrowableVerifier;
+import io.skelp.verifier.verification.Verification;
 
 /**
  * <p>
@@ -48,6 +79,360 @@ public abstract class AbstractCustomVerifierTestCase<T, V extends AbstractCustom
 
     @Mock
     private VerifierAssertion<T> mockAssertion;
+
+    @Test
+    public void testAndWithArray() {
+        Integer[] value = new Integer[]{123, 456, 789};
+        ArrayVerifier<Integer> result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithArrayAndName() {
+        Integer[] value = new Integer[]{123, 456, 789};
+        ArrayVerifier<Integer> result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithBigDecimal() {
+        BigDecimal value = BigDecimal.ONE;
+        BigDecimalVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithBigDecimalAndName() {
+        BigDecimal value = BigDecimal.ONE;
+        BigDecimalVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithBigInteger() {
+        BigInteger value = BigInteger.ONE;
+        BigIntegerVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithBigIntegerAndName() {
+        BigInteger value = BigInteger.ONE;
+        BigIntegerVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithBoolean() {
+        BooleanVerifier result = getCustomVerifier().and(true);
+
+        testAndHelper(result, true, null);
+    }
+
+    @Test
+    public void testAndWithBooleanAndName() {
+        BooleanVerifier result = getCustomVerifier().and(true, "foo");
+
+        testAndHelper(result, true, "foo");
+    }
+
+    @Test
+    public void testAndWithByte() {
+        byte value = 123;
+        ByteVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithByteAndName() {
+        byte value = 123;
+        ByteVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithCalendar() {
+        Calendar value = Calendar.getInstance();
+        CalendarVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithCalendarAndName() {
+        Calendar value = Calendar.getInstance();
+        CalendarVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithCharacter() {
+        char value = 'a';
+        CharacterVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithCharacterAndName() {
+        char value = 'a';
+        CharacterVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithClass() {
+        ClassVerifier result = getCustomVerifier().and(VerifierTest.class);
+
+        testAndHelper(result, VerifierTest.class, null);
+    }
+
+    @Test
+    public void testAndWithClassAndName() {
+        ClassVerifier result = getCustomVerifier().and(VerifierTest.class, "foo");
+
+        testAndHelper(result, VerifierTest.class, "foo");
+    }
+
+    @Test
+    public void testAndWithCollection() {
+        Collection<Integer> value = Arrays.asList(123, 456, 789);
+        CollectionVerifier<Integer> result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithCollectionAndName() {
+        Collection<Integer> value = Arrays.asList(123, 456, 789);
+        CollectionVerifier<Integer> result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithDate() {
+        Date value = new Date();
+        DateVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithDateAndName() {
+        Date value = new Date();
+        DateVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithDouble() {
+        double value = 123D;
+        DoubleVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithDoubleAndName() {
+        double value = 123D;
+        DoubleVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithFloat() {
+        float value = 123F;
+        FloatVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithFloatAndName() {
+        float value = 123F;
+        FloatVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithInteger() {
+        int value = 123;
+        IntegerVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithIntegerAndName() {
+        int value = 123;
+        IntegerVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithLocale() {
+        Locale value = Locale.US;
+        LocaleVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithLocaleAndName() {
+        Locale value = Locale.US;
+        LocaleVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithLong() {
+        long value = 123L;
+        LongVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithLongAndName() {
+        long value = 123L;
+        LongVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithMap() {
+        Map<String, Integer> value = new HashMap<>();
+        value.put("abc", 123);
+        MapVerifier<String, Integer> result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithMapAndName() {
+        Map<String, Integer> value = new HashMap<>();
+        value.put("abc", 123);
+        MapVerifier<String, Integer> result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithObject() {
+        Object value = new Verifier();
+        ObjectVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithObjectAndName() {
+        Object value = new Verifier();
+        ObjectVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithShort() {
+        short value = 123;
+        ShortVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithShortAndName() {
+        short value = 123;
+        ShortVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithString() {
+        StringVerifier result = getCustomVerifier().and("foo");
+
+        testAndHelper(result, "foo", null);
+    }
+
+    @Test
+    public void testAndWithStringAndName() {
+        StringVerifier result = getCustomVerifier().and("foo", "bar");
+
+        testAndHelper(result, "foo", "bar");
+    }
+
+    @Test
+    public void testAndWithThrowable() {
+        Throwable value = new Throwable();
+        ThrowableVerifier result = getCustomVerifier().and(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndWithThrowableAndName() {
+        Throwable value = new Throwable();
+        ThrowableVerifier result = getCustomVerifier().and(value, "foo");
+
+        testAndHelper(result, value, "foo");
+    }
+
+    @Test
+    public void testAndWithCustomVerifierClass() {
+        @SuppressWarnings("unchecked")
+        Verification<String> mockVerification = (Verification<String>) mock(Verification.class);
+        StringVerifier expected = new StringVerifier(mockVerification);
+
+        when(getMockVerification().copy("foo", "bar")).thenReturn(mockVerification);
+
+        when(getMockCustomVerifierProvider().getCustomVerifier(StringVerifier.class, mockVerification)).thenReturn(expected);
+
+        StringVerifier actual = getCustomVerifier().and("foo", "bar", StringVerifier.class);
+
+        assertSame("Uses CustomVerifier created by factory", expected, actual);
+        testAndHelper(actual, "foo", "bar");
+    }
+
+    private <U, C extends CustomVerifier<U, C>> void testAndHelper(CustomVerifier<U, C> verifier, U value, Object name) {
+        assertNotNull("Never returns null", verifier);
+
+        verify(getMockVerification()).copy(value, name);
+    }
+
+    @Test
+    public void testAndComparable() {
+        URI value = URI.create("foo");
+        ComparableVerifier<URI> result = getCustomVerifier().andComparable(value);
+
+        testAndHelper(result, value, null);
+    }
+
+    @Test
+    public void testAndComparableWithName() {
+        URI value = URI.create("foo");
+        ComparableVerifier<URI> result = getCustomVerifier().andComparable(value, "bar");
+
+        testAndHelper(result, value, "bar");
+    }
 
     @Test
     public void testEqualToWithDifferentInstance() {

--- a/src/test/java/io/skelp/verifier/CustomVerifierTestCaseBase.java
+++ b/src/test/java/io/skelp/verifier/CustomVerifierTestCaseBase.java
@@ -122,6 +122,8 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
     @Captor
     private ArgumentCaptor<Object> argsCaptor;
     @Mock
+    private CustomVerifierProvider mockCustomVerifierProvider;
+    @Mock
     private Verification<T> mockVerification;
     @Mock
     private VerificationProvider mockVerificationProvider;
@@ -134,6 +136,7 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
     public void setUp() throws Exception {
         when(mockVerificationProvider.getVerification(any(), any())).thenAnswer(invocation -> new SimpleVerification<>(new SimpleLocaleContext(), new ResourceBundleMessageSource(), new DefaultFormatterProvider(), new DefaultReportExecutorProvider().getReportExecutor(), invocation.getArguments()[0], invocation.getArguments()[1]));
 
+        TestCustomVerifierProvider.setDelegate(mockCustomVerifierProvider);
         TestVerificationProvider.setDelegate(mockVerificationProvider);
 
         when(mockVerification.getValue()).thenAnswer(invocation -> value);
@@ -145,6 +148,7 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
 
     @After
     public void tearDown() throws Exception {
+        TestCustomVerifierProvider.setDelegate(null);
         TestVerificationProvider.setDelegate(null);
     }
 
@@ -177,6 +181,17 @@ public abstract class CustomVerifierTestCaseBase<T, V extends CustomVerifier<T, 
      */
     protected V getCustomVerifier() {
         return customVerifier;
+    }
+
+    /**
+     * <p>
+     * Returns the mock custom verifier provider being used to test the subject.
+     * </p>
+     *
+     * @return The mock {@link CustomVerifierProvider}.
+     */
+    protected CustomVerifierProvider getMockCustomVerifierProvider() {
+        return mockCustomVerifierProvider;
     }
 
     /**

--- a/src/test/java/io/skelp/verifier/verification/SimpleVerificationTest.java
+++ b/src/test/java/io/skelp/verifier/verification/SimpleVerificationTest.java
@@ -41,6 +41,7 @@ import io.skelp.verifier.message.MessageSource;
 import io.skelp.verifier.message.formatter.Formatter;
 import io.skelp.verifier.message.formatter.FormatterProvider;
 import io.skelp.verifier.message.locale.LocaleContext;
+import io.skelp.verifier.util.TestUtils;
 import io.skelp.verifier.verification.report.MessageHolder;
 import io.skelp.verifier.verification.report.ReportExecutor;
 
@@ -54,8 +55,10 @@ import io.skelp.verifier.verification.report.ReportExecutor;
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleVerificationTest {
 
-    private static final Object TEST_NAME = "foo";
-    private static final Object TEST_VALUE = 123;
+    private static final Object TEST_NAME_1 = "foo";
+    private static final Object TEST_NAME_2 = "fu";
+    private static final Object TEST_VALUE_1 = 123;
+    private static final Object TEST_VALUE_2 = 456;
 
     @Captor
     private ArgumentCaptor<MessageHolder> messageHolderCaptor;
@@ -74,7 +77,24 @@ public class SimpleVerificationTest {
 
     @Before
     public void setUp() {
-        verification = new SimpleVerification<>(mockLocaleContext, mockMessageSource, mockFormatterProvider, mockReportExecutor, TEST_VALUE, TEST_NAME);
+        verification = new SimpleVerification<>(mockLocaleContext, mockMessageSource, mockFormatterProvider, mockReportExecutor, TEST_VALUE_1, TEST_NAME_1);
+    }
+
+    @Test
+    public void testCopy() throws Exception {
+        verification.setNegated(true);
+
+        Verification<?> copy = verification.copy(TEST_VALUE_2, TEST_NAME_2);
+
+        assertNotNull("Never returns null", copy);
+        assertTrue("Returns instance of SimpleVerification", copy instanceof SimpleVerification);
+        assertFalse("Copy is not negated", copy.isNegated());
+        assertSame("Reuses FormatterProvider", TestUtils.getInstanceField(verification, "formatterProvider", true), TestUtils.getInstanceField(copy, "formatterProvider", true));
+        assertSame("Reuses LocaleContext", TestUtils.getInstanceField(verification, "localeContext", true), TestUtils.getInstanceField(copy, "localeContext", true));
+        assertSame("Reuses MessageSource", TestUtils.getInstanceField(verification, "messageSource", true), TestUtils.getInstanceField(copy, "messageSource", true));
+        assertSame("Reuses ReportExecutor", TestUtils.getInstanceField(verification, "reportExecutor", true), TestUtils.getInstanceField(copy, "reportExecutor", true));
+        assertEquals("Passed name", TEST_NAME_2, copy.getName());
+        assertEquals("Passed value", TEST_VALUE_2, copy.getValue());
     }
 
     @Test
@@ -185,7 +205,7 @@ public class SimpleVerificationTest {
 
     @Test
     public void testName() {
-        assertEquals("Name property is readable", TEST_NAME, verification.getName());
+        assertEquals("Name property is readable", TEST_NAME_1, verification.getName());
     }
 
     @Test
@@ -199,6 +219,6 @@ public class SimpleVerificationTest {
 
     @Test
     public void testValue() {
-        assertEquals("Value property is readable", TEST_VALUE, verification.getValue());
+        assertEquals("Value property is readable", TEST_VALUE_1, verification.getValue());
     }
 }


### PR DESCRIPTION
This PR adds complimentary methods for `Verifier#verify` and `Verifier#verifyComparable` to `CustomVerifer` as `and` and `andComparable` to make chaining more fluid. Here's the example from the README:

``` java
package com.example.form;

import io.skelp.verifier.Verifier;

public class LoginForm implements Form {

    UserService userService;

    @Override
    public void handle(Map<String, String> data) {
        Verifier.verify(data)
            .containAllKeys("username", "password");
            .and(data.get("username"), "username")
                .not().blank();
            .and(data.get("password"), "password")
                .not().empty()
                .alphanumeric();

        userService.login(data);
    }
}
```